### PR TITLE
decode output of lsb_release as utf-8

### DIFF
--- a/distro.py
+++ b/distro.py
@@ -920,7 +920,7 @@ class LinuxDistribution(object):
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE)
         stdout, stderr = process.communicate()
-        stdout, stderr = stdout.decode('ascii'), stderr.decode('ascii')
+        stdout, stderr = stdout.decode('utf-8'), stderr.decode('utf-8')
         code = process.returncode
         if code == 0:
             content = stdout.splitlines()


### PR DESCRIPTION
This helps for non-US languages, which otherwise traceback.
Fixes #140
