### PR TITLE
Fix bug in RHEL6 detection by distributor id.

### DIFF
--- a/distro.py
+++ b/distro.py
@@ -62,7 +62,8 @@ NORMALIZED_OS_ID = {}
 #: * Value: Normalized value.
 NORMALIZED_LSB_ID = {
     'enterpriseenterprise': 'oracle',  # Oracle Enterprise Linux
-    'redhatenterpriseworkstation': 'rhel',  # RHEL 6.7
+    'redhatenterpriseworkstation': 'rhel',  # RHEL 6, 7 Workstation
+    'redhatenterpriseserver': 'rhel',  # RHEL 6, 7 Server
 }
 
 #: Translation table for normalizing the distro ID derived from the file name

--- a/tests/resources/distros/rhel5/etc/redhat-release
+++ b/tests/resources/distros/rhel5/etc/redhat-release
@@ -1,0 +1,1 @@
+Red Hat Enterprise Linux Server release 5.11 (Tikanga)

--- a/tests/test_distro.py
+++ b/tests/test_distro.py
@@ -1170,6 +1170,28 @@ class TestOverall(DistroTestCase):
         self._test_outcome(desired_outcome)
         self._test_non_existing_release_file()
 
+    def test_rhel5_release(self):
+        desired_outcome = {
+            'id': 'rhel',
+            'name': 'Red Hat Enterprise Linux Server',
+            'pretty_name': 'Red Hat Enterprise Linux Server release 5.11 (Tikanga)',
+            'version': '5.11',
+            'pretty_version': '5.11 (Tikanga)',
+            'best_version': '5.11',
+            'codename': 'Tikanga',
+            'major_version': '5',
+            'minor_version': '11'
+        }
+        self._test_outcome(desired_outcome)
+
+        desired_info = {
+            'id': 'redhat',
+            'name': 'Red Hat Enterprise Linux Server',
+            'version_id': '5.11',
+            'codename': 'Tikanga'
+        }
+        self._test_release_file_info('redhat-release', desired_info)
+
     def test_rhel6_release(self):
         desired_outcome = {
             'id': 'rhel',

--- a/tests/test_distro.py
+++ b/tests/test_distro.py
@@ -1174,7 +1174,7 @@ class TestOverall(DistroTestCase):
         desired_outcome = {
             'id': 'rhel',
             'name': 'Red Hat Enterprise Linux Server',
-            'pretty_name': 'Red Hat Enterprise Linux Server release 5.11 (Tikanga)',
+            'pretty_name': 'Red Hat Enterprise Linux Server 5.11 (Tikanga)',
             'version': '5.11',
             'pretty_version': '5.11 (Tikanga)',
             'best_version': '5.11',


### PR DESCRIPTION
This wasn't working on our RHEL6 clusters.  It seems to figure out that our RHEL7 ones should be called `rhel` by some other means, but on RHEL6 it got down to the distributor ID.  I updated the translation table to include the server release.<br /><br />- There are two types of RHEL: server and workstation.<br />- Distributor ID table only had a string for workstation.<br />- Added a string for server.