### PR TITLE
Race condition in _parse_distro_release_file

### DIFF
--- a/distro.py
+++ b/distro.py
@@ -1012,12 +1012,13 @@ class LinuxDistribution(object):
         Returns:
             A dictionary containing all information items.
         """
-        if os.path.isfile(filepath):
+        try:
             with open(filepath) as fp:
                 # Only parse the first line. For instance, on SLES there
                 # are multiple lines. We don't want them...
                 return self._parse_distro_release_content(fp.readline())
-        return {}
+        except (OSError, IOError):
+            return {}
 
     @staticmethod
     def _parse_distro_release_content(line):


### PR DESCRIPTION
Also happens to fix #162 :)
Instead of checking if the file exists just try and open it and if we can't open it (For whatever reason, if it's not there, no permissions, etc) then we return as if it wasn't there.