### PR TITLE
Fixing how distro deals with inconsistent *-release files.

### DIFF
--- a/distro.py
+++ b/distro.py
@@ -644,9 +644,10 @@ class LinuxDistribution(object):
             distro_id = distro_id.lower().replace(' ', '_')
             return table.get(distro_id, distro_id)
 
-        distro_id, source = self._preferred_release_attr({'os-release': 'id',
-                                                          'lsb-release': 'distributor_id',
-                                                          'distro-release': 'id'})
+        distro_id, source = self._preferred_release_attr({
+            'os-release': 'id',
+            'lsb-release': 'distributor_id',
+            'distro-release': 'id'})
 
         if source == 'os-release':
             return normalize(distro_id, NORMALIZED_OS_ID)
@@ -663,17 +664,19 @@ class LinuxDistribution(object):
         For details, see :func:`distro.name`.
         """
         if pretty:
-            name, source = self._preferred_release_attr({'os-release': 'pretty_name',
-                                                         'lsb-release': 'description',
-                                                         'distro-release': 'name'})
+            name, source = self._preferred_release_attr({
+                'os-release': 'pretty_name',
+                'lsb-release': 'description',
+                'distro-release': 'name'})
             if source == 'distro-release':
                 version = self.version(pretty=True)
                 if version:
                     name = name + ' ' + version
         else:
-            name, _ = self._preferred_release_attr({'os-release': 'name',
-                                                    'lsb-release': 'distributor_id',
-                                                    'distro-release': 'name'})
+            name, _ = self._preferred_release_attr({
+                'os-release': 'name',
+                'lsb-release': 'distributor_id',
+                'distro-release': 'name'})
         return name or ''
 
     def version(self, pretty=False, best=False):
@@ -692,7 +695,8 @@ class LinuxDistribution(object):
                 self.lsb_release_attr('description')).get('version_id', '')
         ]
 
-        # Linux Mint has Ubuntu's version in os-release so exclude it from this list.
+        # Linux Mint has Ubuntu's version in
+        # os-release so exclude it from this list.
         if self.id() != 'linuxmint':
             versions.insert(1, self.os_release_attr('version_id'))
             versions.insert(4, self._parse_distro_release_content(
@@ -1086,16 +1090,17 @@ class LinuxDistribution(object):
 
     def _resolve_distro_inconsistencies(self):
         # Debian stretch/sid does not contain parenthesis in it's PRETTY_NAME
-        # field for /etc/os-release like all other distros so it would hide the
-        # codename from being parsed correctly. This would only occur when lsb-release
-        # is not installed. Issue #152
+        # field for /etc/os-release like all other distros so it would hide
+        # the codename from being parsed correctly. This would only occur
+        # when lsb-release is not installed. See issue #152 for more info.
         if self.id() == 'debian' and self.codename() == '':
             if 'stretch/sid' in self.os_release_attr('pretty_name'):
                 self._os_release_info['codename'] = 'stretch/sid'
 
         # Linux Mint has the same os-release as Ubuntu and lsb-release contains
         # all information about Linux Mint. Change the order that distro gets
-        # information from release files for Linux Mint to prefer lsb-release. Issue #78
+        # information from release files for Linux Mint to prefer lsb-release.
+        # See issue #78 for more info.
         if self.os_release_attr('id') == 'ubuntu' and \
                 self.lsb_release_attr('distributor_id') == 'LinuxMint':
             self._preferred_source_order = ['lsb-release',

--- a/tests/resources/special/debian_stretch_docker/etc/os-release
+++ b/tests/resources/special/debian_stretch_docker/etc/os-release
@@ -1,0 +1,6 @@
+PRETTY_NAME="Debian GNU/Linux stretch/sid"
+NAME="Debian GNU/Linux"
+ID=debian
+HOME_URL="https://www.debian.org/"
+SUPPORT_URL="https://www.debian.org/support"
+BUG_REPORT_URL="https://bugs.debian.org/"

--- a/tests/test_distro.py
+++ b/tests/test_distro.py
@@ -1030,16 +1030,16 @@ class TestOverall(DistroTestCase):
 
     def test_linuxmint17_release(self):
         desired_outcome = {
-            'id': 'ubuntu',
-            'name': 'Ubuntu',
-            'pretty_name': 'Ubuntu 14.04.3 LTS',
-            'version': '14.04',
-            'pretty_version': '14.04 (Trusty Tahr)',
-            'best_version': '14.04.3',
+            'id': 'linuxmint',
+            'name': 'LinuxMint',
+            'pretty_name': 'Linux Mint 17.3 Rosa',
+            'version': '17.3',
+            'pretty_version': '17.3 (rosa)',
+            'best_version': '17.3',
             'like': 'debian',
-            'codename': 'Trusty Tahr',
-            'major_version': '14',
-            'minor_version': '04'
+            'codename': 'rosa',
+            'major_version': '17',
+            'minor_version': '3'
         }
         self._test_outcome(desired_outcome)
         self._test_non_existing_release_file()

--- a/tests/test_distro.py
+++ b/tests/test_distro.py
@@ -566,6 +566,18 @@ class TestSpecialRelease(DistroTestCase):
         }
         self._test_outcome(desired_outcome)
 
+    def test_debian_stretch_docker_release(self):
+        self._setup_for_distro(os.path.join(SPECIAL, 'debian_stretch_docker'))
+        self.distro = distro.LinuxDistribution()
+
+        desired_outcome = {
+            'id': 'debian',
+            'name': 'Debian GNU/Linux',
+            'pretty_name': 'Debian GNU/Linux stretch/sid',
+            'codename': 'stretch/sid',
+        }
+        self._test_outcome(desired_outcome)
+
 
 @pytest.mark.skipif(not IS_LINUX, reason='Irrelevant on non-linux')
 class TestDistroRelease:
@@ -1818,4 +1830,6 @@ class TestRepr:
         repr_str = repr(distro._distro)
         assert "LinuxDistribution" in repr_str
         for attr in MODULE_DISTRO.__dict__.keys():
+            if attr == '_preferred_source_order':
+                continue
             assert attr + '=' in repr_str


### PR DESCRIPTION
So this PR is a minimal (and IMO rather hacky) solution to the two cases where distro has trouble with getting the right information from *-release files. The two related issues are #78 for Linux Mint and #152 for Debian stretch/sid when lsb-release isn't installed. I don't think this solution should be merged, might be a good place for some discussion about the proper direction.

If I were to be able to make more changes it might be nice to have `distro.LinuxDistribution()` do all it's parsing, assigns values, and then return a class that does minimal logic and spits out those values when they're queried.  Could still keep same interface including `os_release_attr`, `lsb_release_attr`, etc. Would allow for a cleaner layout of where special cases happen rather than have each special case occur within the `id()`, `codename()` and `version()` functions. I think this would be a much better route to go, especially for when future inconsistencies are found.

Thoughts?