### PR TITLE
Distro Inconsistencies Framework

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+**2.0.0 (dev)**
+
+* Added framework for distro to detect and correct reported information in the case of a Linux distro inconsistency.
+* Added `get_implementation` which should be used to get a `LinuxDistribution` object.
+
 **1.0.4 (2017.04.01)**
 
 * Fix not being able to read `/etc/` and yet able to read release files inside it.

--- a/distro.py
+++ b/distro.py
@@ -898,7 +898,7 @@ class LinuxDistribution(object):
                         codename = codename.strip('()')
                         codename = codename.strip(',')
                         codename = codename.strip()
-                        # codename appears within paranthese.
+                        # codename appears within parenthesis.
                         props['codename'] = codename
                     else:
                         props['codename'] = ''
@@ -1092,20 +1092,19 @@ class LinuxMintDistribution(LinuxDistribution):
 
 
 class CloudLinuxDistribution(LinuxDistribution):
-    """ CloudLinux <7 doesn't provide an lsb-release or os-release file,
-    only a redhat-release file so it's id is incorrectly detected as `rhel`.
-    """
     def id(self):
+        """ CloudLinux <7 doesn't provide an lsb-release or
+        os-release file, only a redhat-release file so it's id
+        is incorrectly detected as `rhel`. """
         return 'cloudlinux'
 
 
-class DebianDistribution(LinuxDistribution):
-    """ Starting with Debian 9 (stretch) the information inside of
-    /etc/os-release does not follow the same standards for codenames
-    that all other distros follow thus custom detection of Debians
-    codename is required. """
+class DebianStretchDistribution(LinuxDistribution):
     def _parse_os_release_content(self, lines):
-        props = (super(DebianDistribution, self).
+        """ Debian 9 (stretch) does not have the codename
+        in parenthesis or with a comma unlike all other
+        distributions. This stub """
+        props = (super(DebianStretchDistribution, self).
                  _parse_os_release_content(lines))
         if 'codename' not in props and props.get('pretty_name', ''):
             pretty_name = props['pretty_name']
@@ -1120,7 +1119,7 @@ class DebianDistribution(LinuxDistribution):
         return props
 
 
-def get_implementation(*args):
+def get_distribution(*args):
     """ Gets the proper implementation of LinuxDistribution after attempting
     to detect distro inconsistencies. Passes all args through to the resulting
     LinuxDistribution object. """
@@ -1133,13 +1132,13 @@ def get_implementation(*args):
         return LinuxMintDistribution(*args)
     elif ld.id() == 'rhel' and 'CloudLinux' in ld.name():
         return CloudLinuxDistribution(*args)
-    elif ld.id() == 'debian':
-        return DebianDistribution(*args)
+    elif ld.id() == 'debian' and ld.codename() == '':
+        return DebianStretchDistribution(*args)
     else:
         return ld
 
 
-_distro = get_implementation()
+_distro = get_distribution()
 
 
 def main():

--- a/distro.py
+++ b/distro.py
@@ -1086,23 +1086,27 @@ class LinuxMintDistribution(LinuxDistribution):
     from that file except `ID_LIKE`. """
     def os_release_attr(self, attribute):
         if attribute == 'id_like':
-            return super(LinuxMintDistribution, self).os_release_attr(attribute)
+            v = super(LinuxMintDistribution, self).os_release_attr(attribute)
+            return v
         return ''
 
 
 class CloudLinuxDistribution(LinuxDistribution):
     """ CloudLinux <7 doesn't provide an lsb-release or os-release file,
-    only a redhat-release file so it's id is incorrectly detected as `rhel`. """
+    only a redhat-release file so it's id is incorrectly detected as `rhel`.
+    """
     def id(self):
         return 'cloudlinux'
 
 
 class DebianDistribution(LinuxDistribution):
-    """ Starting with Debian 9 (stretch) the information inside of /etc/os-release
-    does not follow the same standards for codenames that all other distros follow
-    thus custom detection of Debian's codename is required. """
+    """ Starting with Debian 9 (stretch) the information inside of
+    /etc/os-release does not follow the same standards for codenames
+    that all other distros follow thus custom detection of Debians
+    codename is required. """
     def _parse_os_release_content(self, lines):
-        props = super(DebianDistribution, self)._parse_os_release_content(lines)
+        props = (super(DebianDistribution, self).
+                 _parse_os_release_content(lines))
         if 'codename' not in props and props.get('pretty_name', ''):
             match = re.search(r'\s([^\s\d]+)$', props['pretty_name'])
             if match:
@@ -1113,7 +1117,9 @@ class DebianDistribution(LinuxDistribution):
 def get_implementation(*args):
     ld = LinuxDistribution(*args)
     os_release_id = _normalize_id(ld.os_release_attr('id'), NORMALIZED_OS_ID)
-    lsb_release_id = _normalize_id(ld.lsb_release_attr('distributor_id'), NORMALIZED_LSB_ID)
+    lsb_release_id = _normalize_id(ld.lsb_release_attr('distributor_id'),
+                                   NORMALIZED_LSB_ID)
+
     if os_release_id == 'ubuntu' and lsb_release_id == 'linuxmint':
         return LinuxMintDistribution(*args)
     elif ld.id() == 'rhel' and 'CloudLinux' in ld.name():

--- a/distro.py
+++ b/distro.py
@@ -1090,12 +1090,21 @@ class LinuxMintDistribution(LinuxDistribution):
         return ''
 
 
+class CloudLinuxDistribution(LinuxDistribution):
+    """ CloudLinux <7 doesn't provide an lsb-release or os-release file,
+    only a redhat-release file so it's id is incorrectly detected as `rhel`. """
+    def id(self):
+        return 'cloudlinux'
+
+
 def get_implementation(*args):
     ld = LinuxDistribution(*args)
     os_release_id = _normalize_id(ld.os_release_attr('id'), NORMALIZED_OS_ID)
     lsb_release_id = _normalize_id(ld.lsb_release_attr('distributor_id'), NORMALIZED_LSB_ID)
     if os_release_id == 'ubuntu' and lsb_release_id == 'linuxmint':
         return LinuxMintDistribution(*args)
+    elif ld.id() == 'rhel' and 'CloudLinux' in ld.name():
+        return CloudLinuxDistribution()
     else:
         return ld
 

--- a/tests/resources/distros/debian9/etc/os-release
+++ b/tests/resources/distros/debian9/etc/os-release
@@ -1,0 +1,6 @@
+PRETTY_NAME="Debian GNU/Linux stretch/sid"
+NAME="Debian GNU/Linux"
+ID=debian
+HOME_URL="https://www.debian.org/"
+SUPPORT_URL="https://www.debian.org/support"
+BUG_REPORT_URL="https://bugs.debian.org/"

--- a/tests/resources/special/debian_no_codename/etc/os-release
+++ b/tests/resources/special/debian_no_codename/etc/os-release
@@ -1,0 +1,6 @@
+PRETTY_NAME="Debian GNU/Linux"
+NAME="Debian GNU/Linux"
+ID=debian
+HOME_URL="https://www.debian.org/"
+SUPPORT_URL="https://www.debian.org/support"
+BUG_REPORT_URL="https://bugs.debian.org/"

--- a/tests/test_distro.py
+++ b/tests/test_distro.py
@@ -117,7 +117,7 @@ class TestOSRelease:
     def setup_method(self, test_method):
         dist = test_method.__name__.split('_')[1]
         os_release = os.path.join(DISTROS_DIR, dist, 'etc', 'os-release')
-        self.distro = distro.get_implementation(False, os_release, 'non')
+        self.distro = distro.get_distribution(False, os_release, 'non')
 
     def _test_outcome(self, outcome):
         assert self.distro.id() == outcome.get('id', '')
@@ -175,12 +175,12 @@ class TestOSRelease:
         }
         self._test_outcome(desired_outcome)
 
-    def test_debian9_release(self):
+    def test_debian9_os_release(self):
         desired_outcome = {
             'id': 'debian',
             'name': 'Debian GNU/Linux',
             'pretty_name': 'Debian GNU/Linux stretch/sid',
-            'codename': 'stretch/sid',
+            'codename': 'stretch/sid'
         }
         self._test_outcome(desired_outcome)
 
@@ -409,7 +409,7 @@ class TestLSBRelease(DistroTestCase):
         self.test_method_name = test_method.__name__
         dist = test_method.__name__.split('_')[1]
         self._setup_for_distro(os.path.join(DISTROS_DIR, dist))
-        self.distro = distro.get_implementation(True, 'non', 'non')
+        self.distro = distro.get_distribution(True, 'non', 'non')
 
     def _test_outcome(self, outcome):
         assert self.distro.id() == outcome.get('id', '')
@@ -445,20 +445,6 @@ class TestLSBRelease(DistroTestCase):
             'best_version': '15.12',
             'codename': 'Capella'
         })
-
-    # @pytest.mark.xfail
-    # def test_openelec6_lsb_release(self):
-    #     # TODO: This should be fixed as part of #109 when dealing
-    #     # with distro inconsistencies
-    #     desired_outcome = {
-    #         'id': 'openelec',
-    #         'name': 'OpenELEC',
-    #         'pretty_name': 'OpenELEC (official) - Version: 6.0.3',
-    #         'version': '6.0.3',
-    #         'pretty_version': '6.0.3',
-    #         'best_version': '6.0.3',
-    #     }
-    #     self._test_outcome(desired_outcome)
 
     def test_ubuntu14normal_lsb_release(self):
         self._setup_for_distro(os.path.join(TESTDISTROS, 'lsb',
@@ -593,7 +579,7 @@ class TestSpecialRelease(DistroTestCase):
     def test_debian_distribution_pretty_name_has_no_codename(self):
         self._setup_for_distro(os.path.join(SPECIAL, 'debian_no_codename'))
 
-        self.distro = distro.get_implementation()
+        self.distro = distro.get_distribution()
 
         desired_outcome = {
             'id': 'debian',
@@ -617,7 +603,7 @@ class TestDistroRelease:
         distro_release = os.path.join(
             DISTROS_DIR, distro_name + version, 'etc', '{0}-{1}'.format(
                 release_file_id, release_file_suffix))
-        self.distro = distro.get_implementation(False, 'non', distro_release)
+        self.distro = distro.get_distribution(False, 'non', distro_release)
 
         assert self.distro.id() == outcome.get('id', '')
         assert self.distro.name() == outcome.get('name', '')
@@ -905,7 +891,7 @@ class TestOverall(DistroTestCase):
         super(TestOverall, self).setup_method(test_method)
         dist = test_method.__name__.split('_')[1]
         self._setup_for_distro(os.path.join(DISTROS_DIR, dist))
-        self.distro = distro.get_implementation()
+        self.distro = distro.get_distribution()
 
     def _test_outcome(self, outcome):
         assert self.distro.id() == outcome.get('id', '')
@@ -1121,7 +1107,6 @@ class TestOverall(DistroTestCase):
             'pretty_version': '5 (thornicroft)',
             'best_version': '5',
             'like': 'mandriva fedora',
-            # TODO: Codename differs between distro release and lsb_release.
             'codename': 'thornicroft',
             'major_version': '5'
         }

--- a/tests/test_distro.py
+++ b/tests/test_distro.py
@@ -590,6 +590,19 @@ class TestSpecialRelease(DistroTestCase):
         }
         self._test_outcome(desired_outcome)
 
+    def test_debian_distribution_pretty_name_has_no_codename(self):
+        self._setup_for_distro(os.path.join(SPECIAL, 'debian_no_codename'))
+
+        self.distro = distro.get_implementation()
+
+        desired_outcome = {
+            'id': 'debian',
+            'name': 'Debian GNU/Linux',
+            'pretty_name': 'Debian GNU/Linux',
+            'codename': '',
+        }
+        self._test_outcome(desired_outcome)
+
 
 @pytest.mark.skipif(not IS_LINUX, reason='Irrelevant on non-linux')
 class TestDistroRelease:

--- a/tests/test_distro.py
+++ b/tests/test_distro.py
@@ -1461,7 +1461,7 @@ class TestOverall(DistroTestCase):
         # Uses redhat-release only to get information.
         # The id of 'rhel' can only be fixed with issue #109.
         desired_outcome = {
-            'id': 'rhel',
+            'id': 'cloudlinux',
             'codename': 'Vladislav Volkov',
             'name': 'CloudLinux Server',
             'pretty_name': 'CloudLinux Server 5.11 (Vladislav Volkov)',
@@ -1476,7 +1476,7 @@ class TestOverall(DistroTestCase):
     def test_cloudlinux6_release(self):
         # Same as above, only has redhat-release.
         desired_outcome = {
-            'id': 'rhel',
+            'id': 'cloudlinux',
             'codename': 'Oleg Makarov',
             'name': 'CloudLinux Server',
             'pretty_name': 'CloudLinux Server 6.8 (Oleg Makarov)',

--- a/tests/test_distro.py
+++ b/tests/test_distro.py
@@ -117,7 +117,7 @@ class TestOSRelease:
     def setup_method(self, test_method):
         dist = test_method.__name__.split('_')[1]
         os_release = os.path.join(DISTROS_DIR, dist, 'etc', 'os-release')
-        self.distro = distro.LinuxDistribution(False, os_release, 'non')
+        self.distro = distro.get_implementation(False, os_release, 'non')
 
     def _test_outcome(self, outcome):
         assert self.distro.id() == outcome.get('id', '')
@@ -172,6 +172,15 @@ class TestOSRelease:
             'pretty_version': '8 (jessie)',
             'best_version': '8',
             'codename': 'jessie'
+        }
+        self._test_outcome(desired_outcome)
+
+    def test_debian9_release(self):
+        desired_outcome = {
+            'id': 'debian',
+            'name': 'Debian GNU/Linux',
+            'pretty_name': 'Debian GNU/Linux stretch/sid',
+            'codename': 'stretch/sid',
         }
         self._test_outcome(desired_outcome)
 
@@ -400,7 +409,7 @@ class TestLSBRelease(DistroTestCase):
         self.test_method_name = test_method.__name__
         dist = test_method.__name__.split('_')[1]
         self._setup_for_distro(os.path.join(DISTROS_DIR, dist))
-        self.distro = distro.LinuxDistribution(True, 'non', 'non')
+        self.distro = distro.get_implementation(True, 'non', 'non')
 
     def _test_outcome(self, outcome):
         assert self.distro.id() == outcome.get('id', '')
@@ -595,7 +604,7 @@ class TestDistroRelease:
         distro_release = os.path.join(
             DISTROS_DIR, distro_name + version, 'etc', '{0}-{1}'.format(
                 release_file_id, release_file_suffix))
-        self.distro = distro.LinuxDistribution(False, 'non', distro_release)
+        self.distro = distro.get_implementation(False, 'non', distro_release)
 
         assert self.distro.id() == outcome.get('id', '')
         assert self.distro.name() == outcome.get('name', '')
@@ -811,7 +820,7 @@ class TestDistroRelease:
         # Uses redhat-release only to get information.
         # The id of 'rhel' can only be fixed with issue #109.
         desired_outcome = {
-            'id': 'rhel',
+            'id': 'cloudlinux',
             'codename': 'Vladislav Volkov',
             'name': 'CloudLinux Server',
             'pretty_name': 'CloudLinux Server 5.11 (Vladislav Volkov)',
@@ -826,7 +835,7 @@ class TestDistroRelease:
     def test_cloudlinux6_dist_release(self):
         # Same as above, only has redhat-release.
         desired_outcome = {
-            'id': 'rhel',
+            'id': 'cloudlinux',
             'codename': 'Oleg Makarov',
             'name': 'CloudLinux Server',
             'pretty_name': 'CloudLinux Server 6.8 (Oleg Makarov)',
@@ -840,7 +849,7 @@ class TestDistroRelease:
 
     def test_cloudlinux7_dist_release(self):
         desired_outcome = {
-            'id': 'rhel',
+            'id': 'cloudlinux',
             'codename': 'Yury Malyshev',
             'name': 'CloudLinux',
             'pretty_name': 'CloudLinux 7.3 (Yury Malyshev)',
@@ -1458,8 +1467,6 @@ class TestOverall(DistroTestCase):
         self._test_release_file_info('mandrake-release', desired_info)
 
     def test_cloudlinux5_release(self):
-        # Uses redhat-release only to get information.
-        # The id of 'rhel' can only be fixed with issue #109.
         desired_outcome = {
             'id': 'cloudlinux',
             'codename': 'Vladislav Volkov',
@@ -1474,7 +1481,6 @@ class TestOverall(DistroTestCase):
         self._test_outcome(desired_outcome)
 
     def test_cloudlinux6_release(self):
-        # Same as above, only has redhat-release.
         desired_outcome = {
             'id': 'cloudlinux',
             'codename': 'Oleg Makarov',

--- a/tests/test_distro.py
+++ b/tests/test_distro.py
@@ -883,7 +883,7 @@ class TestOverall(DistroTestCase):
         super(TestOverall, self).setup_method(test_method)
         dist = test_method.__name__.split('_')[1]
         self._setup_for_distro(os.path.join(DISTROS_DIR, dist))
-        self.distro = distro.LinuxDistribution()
+        self.distro = distro.get_implementation()
 
     def _test_outcome(self, outcome):
         assert self.distro.id() == outcome.get('id', '')
@@ -1076,16 +1076,16 @@ class TestOverall(DistroTestCase):
 
     def test_linuxmint17_release(self):
         desired_outcome = {
-            'id': 'ubuntu',
-            'name': 'Ubuntu',
-            'pretty_name': 'Ubuntu 14.04.3 LTS',
-            'version': '14.04',
-            'pretty_version': '14.04 (Trusty Tahr)',
-            'best_version': '14.04.3',
+            'id': 'linuxmint',
+            'name': 'LinuxMint',
+            'pretty_name': 'Linux Mint 17.3 Rosa',
+            'version': '17.3',
+            'pretty_version': '17.3 (rosa)',
+            'best_version': '17.3',
             'like': 'debian',
-            'codename': 'Trusty Tahr',
-            'major_version': '14',
-            'minor_version': '04'
+            'codename': 'rosa',
+            'major_version': '17',
+            'minor_version': '3'
         }
         self._test_outcome(desired_outcome)
         self._test_non_existing_release_file()


### PR DESCRIPTION
These are some of the changes for working towards v2.

### Changes

- Added `get_implementation()` which will choose which `LinuxDistribution` sub-class to use based on known inconsistencies within Linux distros.
- Added `LinuxMintDistribution` which will not use most values from `/etc/os-release` if the file is not changed from upstream Ubuntu.
- Added `CloudLinuxDistribution` which will always return an id of `cloudlinux` even if there are only `/etc/redhat-release` files available.
- Added `DebianDistribution` which will detect the new format that Debian is using for codenames within `/etc/os-release` `PRETTY_NAME` value in the case that `lsb_release` is not available. (Note I still don't have the complete set of `/etc/*-release` files from Debian 9, I didn't actually check. I was just going off the data that was provided in #109.

### References

#109 #180 #184 

cc: @nir0s @xavfernandez @andy-maier @MartijnBraam @funkyfuture
