### PR TITLE
Remove Official Python26 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ matrix:
   include:
     - env: TOXENV=flake8
     - env: TOXENV=py3flake8
-    - python: 2.6 # these are just to make travis's UI a bit prettier
-      env: TOXENV=py26
     - python: 2.7
       env: TOXENV=py27
     - python: 3.3

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ namely from these data sources (from high to low precedence):
 
 ## Python and Distribution Support
 
-`distro` is supported and tested on Python 2.6, 2.7, 3.3+ and PyPy and on
+`distro` is supported and tested on Python 2.7, 3.3+ and PyPy and on
 any Linux distribution that provides one or more of the data sources
 covered.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,11 +20,11 @@ If you want to jump into the API description right away, read about the
 Compatibility
 =============
 
-The ``distro`` package is supported on Python 2.6, 2.7, 3.3+ and PyPy, and on
+The ``distro`` package is supported on Python 2.7, 3.3+ and PyPy, and on
 any Linux distribution that provides one or more of the `data sources`_
 used by this package.
 
-This package is tested on Python 2.6, 2.7, 3.3+ and PyPy, with test data that
+This package is tested on Python 2.7, 3.3+ and PyPy, with test data that
 mimics the exact behavior of the data sources of
 `a number of Linux distributions <https://github.com/nir0s/distro/tree/master/tests/resources/distros>`_.
 

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         'Intended Audience :: System Administrators',
         'License :: OSI Approved :: Apache Software License',
         'Operating System :: POSIX :: Linux',
-        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',

--- a/setup.py
+++ b/setup.py
@@ -22,12 +22,6 @@ package_version = "1.0.4"
 
 here = os.path.abspath(os.path.dirname(__file__))
 
-try:
-    import argparse  # NOQA
-    install_requires = []
-except ImportError:
-    install_requires = ['argparse']
-
 
 def read(*parts):
     # intentionally *not* adding an encoding option to open
@@ -45,7 +39,6 @@ setup(
     description='Linux Distribution - a Linux OS platform information API',
     long_description=read('README.rst'),
     py_modules=['distro'],
-    install_requires=install_requires,
     entry_points={
         'console_scripts': [
             'distro = distro:main',

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@
 
 [tox]
 minversion = 1.7.2
-envlist = flake8, py3flake8, py26, py27, py33, py34, py35, py36, pypy
+envlist = flake8, py3flake8, py27, py33, py34, py35, py36, pypy
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
* Remove pyt2.6 in all testing environments.
* Remove implicit argparse installation for py2.6.