### PR TITLE
Drop python3.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ matrix:
     - env: TOXENV=py3flake8
     - python: 2.7
       env: TOXENV=py27
-    - python: 3.3
-      env: TOXENV=py33
     - python: 3.4
       env: TOXENV=py34
     - python: 3.5

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ namely from these data sources (from high to low precedence):
 
 ## Python and Distribution Support
 
-`distro` is supported and tested on Python 2.7, 3.3+ and PyPy and on
+`distro` is supported and tested on Python 2.7, 3.4+ and PyPy and on
 any Linux distribution that provides one or more of the data sources
 covered.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,11 +20,11 @@ If you want to jump into the API description right away, read about the
 Compatibility
 =============
 
-The ``distro`` package is supported on Python 2.7, 3.3+ and PyPy, and on
+The ``distro`` package is supported on Python 2.7, 3.4+ and PyPy, and on
 any Linux distribution that provides one or more of the `data sources`_
 used by this package.
 
-This package is tested on Python 2.7, 3.3+ and PyPy, with test data that
+This package is tested on Python 2.7, 3.4+ and PyPy, with test data that
 mimics the exact behavior of the data sources of
 `a number of Linux distributions <https://github.com/nir0s/distro/tree/master/tests/resources/distros>`_.
 

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',


### PR DESCRIPTION
Python3.3 has been end of lifed.  The tests have begun failing due to upstreams dropping support as well (notably pytest).

Like [the dropping of 2.6](https://github.com/nir0s/distro/pull/195) this doesn't necessarily mean that distro won't work on 3.3 but rather that it won't be tested on it.