### PR TITLE
Don't raise ImportError on non-linux platforms

### DIFF
--- a/distro.py
+++ b/distro.py
@@ -38,9 +38,6 @@ import argparse
 import subprocess
 
 
-if not sys.platform.startswith('linux'):
-    raise ImportError('Unsupported platform: {0}'.format(sys.platform))
-
 _UNIXCONFDIR = os.environ.get('UNIXCONFDIR', '/etc')
 _OS_RELEASE_BASENAME = 'os-release'
 


### PR DESCRIPTION
In order to be able to use `distro` in cross-platform programs without duplicated import guards, `distro` shouldn't raise on `import`.

For what it's worth, after this patch `distro` acts _mostly_ in the same way as `platform.linux_distribution` on non-linux platforms:

```
>>> platform.linux_distribution()
('', '', '')
>>> distro.id(), distro.version(), distro.codename()
('', '', '')
```