### PR TITLE
Regain Python 2.6 support

### DIFF
--- a/distro.py
+++ b/distro.py
@@ -938,7 +938,7 @@ class LinuxDistribution(object):
         with open(os.devnull, 'w') as devnull:
             try:
                 cmd = ('lsb_release', '-a')
-                stdout = check_output(cmd, stderr=devnull)
+                stdout = self.check_output(cmd, stderr=devnull)
             except OSError:  # Command not found
                 return {}
         content = stdout.decode(sys.getfilesystemencoding()).splitlines()

--- a/distro.py
+++ b/distro.py
@@ -518,7 +518,7 @@ class cached_property(object):
         self._f = f
 
     def __get__(self, obj, owner):
-        assert obj is not None, 'call {} on an instance'.format(self._fname)
+        assert obj is not None, 'call {0} on an instance'.format(self._fname)
         ret = obj.__dict__[self._fname] = self._f(obj)
         return ret
 
@@ -917,6 +917,14 @@ class LinuxDistribution(object):
                 pass
         return props
 
+    def check_output(*args, **kwargs):
+        """Run command with arguments and return its output as a byte string.
+
+        Same as subprocess.check_output(), but works before Python 2.7."""
+
+        p = subprocess.Popen(stdout=subprocess.PIPE, *args, **kwargs)
+        return p.communicate()[0].strip()
+
     @cached_property
     def _lsb_release_info(self):
         """
@@ -930,7 +938,7 @@ class LinuxDistribution(object):
         with open(os.devnull, 'w') as devnull:
             try:
                 cmd = ('lsb_release', '-a')
-                stdout = subprocess.check_output(cmd, stderr=devnull)
+                stdout = check_output(cmd, stderr=devnull)
             except OSError:  # Command not found
                 return {}
         content = stdout.decode(sys.getfilesystemencoding()).splitlines()

--- a/distro.py
+++ b/distro.py
@@ -917,14 +917,6 @@ class LinuxDistribution(object):
                 pass
         return props
 
-    def check_output(*args, **kwargs):
-        """Run command with arguments and return its output as a byte string.
-
-        Same as subprocess.check_output(), but works before Python 2.7."""
-
-        p = subprocess.Popen(stdout=subprocess.PIPE, *args, **kwargs)
-        return p.communicate()[0].strip()
-
     @cached_property
     def _lsb_release_info(self):
         """
@@ -938,7 +930,7 @@ class LinuxDistribution(object):
         with open(os.devnull, 'w') as devnull:
             try:
                 cmd = ('lsb_release', '-a')
-                stdout = self.check_output(cmd, stderr=devnull)
+                stdout = subprocess.Popen(cmd, stderr=devnull).communicate()[0]
             except OSError:  # Command not found
                 return {}
         content = stdout.decode(sys.getfilesystemencoding()).splitlines()

--- a/distro.py
+++ b/distro.py
@@ -917,6 +917,42 @@ class LinuxDistribution(object):
                 pass
         return props
 
+    def _check_output(*popenargs, **kwargs):
+        r"""Run command with arguments and return its output as a byte string.
+
+        If the exit code was non-zero it raises a CalledProcessError.  The
+        CalledProcessError object will have the return code in the returncode
+        attribute and output in the output attribute.
+
+        The arguments are the same as for the Popen constructor.  Example:
+
+        >>> check_output(["ls", "-l", "/dev/null"])
+        'crw-rw-rw- 1 root root 1, 3 Oct 18  2007 /dev/null\n'
+
+        The stdout argument is not allowed as it is used internally.
+        To capture standard error in the result, use stderr=STDOUT.
+
+        >>> check_output(["/bin/sh", "-c",
+        ...               "ls -l non_existent_file ; exit 0"],
+        ...              stderr=STDOUT)
+        'ls: non_existent_file: No such file or directory\n'
+        """
+        if 'stdout' in kwargs:
+            raise ValueError(
+                'stdout argument not allowed, it will be overridden.'
+            )
+        process = subprocess.Popen(
+            stdout=subprocess.PIPE, *popenargs, **kwargs
+        )
+        output, unused_err = process.communicate()
+        retcode = process.poll()
+        if retcode:
+            cmd = kwargs.get("args")
+            if cmd is None:
+                cmd = popenargs[0]
+            raise subprocess.CalledProcessError(retcode, cmd, output=output)
+        return output
+
     @cached_property
     def _lsb_release_info(self):
         """
@@ -930,7 +966,7 @@ class LinuxDistribution(object):
         with open(os.devnull, 'w') as devnull:
             try:
                 cmd = ('lsb_release', '-a')
-                stdout = subprocess.Popen(cmd, stderr=devnull).communicate()[0]
+                stdout = self._check_output(cmd, stderr=devnull)
             except OSError:  # Command not found
                 return {}
         content = stdout.decode(sys.getfilesystemencoding()).splitlines()


### PR DESCRIPTION
The [Spack](https://github.com/spack/spack) package manager uses `distro` to determine which Linux distribution we run on. Spack still supports Python 2.6. I noticed that official 2.6 support was dropped in #195. This pull request should fix the only problems we noticed with Python 2.6.