### PR TITLE
Use Markdown for long description in setup.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,0 @@
-Distro - an OS platform information API
-=======================================
-
-See `Official GitHub repo <https://github.com/nir0s/distro#distro---a-linux-os-platform-information-api>`_.

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,8 @@ setup(
     license='Apache License, Version 2.0',
     platforms='All',
     description='Distro - an OS platform information API',
-    long_description=read('README.rst'),
+    long_description=read('README.md'),
+    long_description_content_type='text/markdown',
     py_modules=['distro'],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
This should make https://pypi.org/project/distro much more useful.

You'll need setuptools 38.6.0+ and twine 1.11+ to release/upload this; see Dustin Ingram's blog:
https://dustingram.com/articles/2018/03/16/markdown-descriptions-on-pypi