### PR TITLE
Update Oracle matching

### DIFF
--- a/distro.py
+++ b/distro.py
@@ -48,7 +48,9 @@ _OS_RELEASE_BASENAME = 'os-release'
 #:   with blanks translated to underscores.
 #:
 #: * Value: Normalized value.
-NORMALIZED_OS_ID = {}
+NORMALIZED_OS_ID = {
+    'ol': 'oracle',  # Oracle Enterprise Linux
+}
 
 #: Translation table for normalizing the "Distributor ID" attribute returned by
 #: the lsb_release command, for use by the :func:`distro.id` method.

--- a/tests/resources/distros/oracle7/etc/oracle-release
+++ b/tests/resources/distros/oracle7/etc/oracle-release
@@ -1,1 +1,1 @@
-Oracle Linux Server release 7.1
+Oracle Linux Server release 7.5

--- a/tests/resources/distros/oracle7/etc/os-release
+++ b/tests/resources/distros/oracle7/etc/os-release
@@ -1,0 +1,14 @@
+NAME="Oracle Linux Server"
+VERSION="7.5"
+ID="ol"
+VERSION_ID="7.5"
+PRETTY_NAME="Oracle Linux Server 7.5"
+ANSI_COLOR="0;31"
+CPE_NAME="cpe:/o:oracle:linux:7:5:server"
+HOME_URL="https://linux.oracle.com/"
+BUG_REPORT_URL="https://bugzilla.oracle.com/"
+
+ORACLE_BUGZILLA_PRODUCT="Oracle Linux 7"
+ORACLE_BUGZILLA_PRODUCT_VERSION=7.5
+ORACLE_SUPPORT_PRODUCT="Oracle Linux"
+ORACLE_SUPPORT_PRODUCT_VERSION=7.5

--- a/tests/test_distro.py
+++ b/tests/test_distro.py
@@ -765,12 +765,12 @@ class TestDistroRelease:
         desired_outcome = {
             'id': 'oracle',
             'name': 'Oracle Linux Server',
-            'pretty_name': 'Oracle Linux Server 7.1',
-            'version': '7.1',
-            'pretty_version': '7.1',
-            'best_version': '7.1',
+            'pretty_name': 'Oracle Linux Server 7.5',
+            'version': '7.5',
+            'pretty_version': '7.5',
+            'best_version': '7.5',
             'major_version': '7',
-            'minor_version': '1'
+            'minor_version': '5'
         }
         self._test_outcome(desired_outcome, 'oracle', '7')
 
@@ -1183,19 +1183,19 @@ class TestOverall(DistroTestCase):
         desired_outcome = {
             'id': 'oracle',
             'name': 'Oracle Linux Server',
-            'pretty_name': 'Oracle Linux Server 7.1',
-            'version': '7.1',
-            'pretty_version': '7.1',
-            'best_version': '7.1',
+            'pretty_name': 'Oracle Linux Server 7.5',
+            'version': '7.5',
+            'pretty_version': '7.5',
+            'best_version': '7.5',
             'major_version': '7',
-            'minor_version': '1'
+            'minor_version': '5'
         }
         self._test_outcome(desired_outcome)
 
         desired_info = {
             'id': 'oracle',
             'name': 'Oracle Linux Server',
-            'version_id': '7.1',
+            'version_id': '7.5',
         }
         distro_info = self._test_release_file_info(
             'oracle-release', desired_info)


### PR DESCRIPTION
It seems Oracle ships an /etc/os-release which has an ID of 'ol'.  To
make sure it returns the id "oracle" as mentioned in the docs, match
this.  Update the testing.

---

I noticed this from the following change which was proposed to OpenStack's bindep : https://review.openstack.org/#/c/536355/

You can see some small testing pulling it from docker in http://paste.openstack.org/show/726682/.  I confirmed I got "oracle" back there too with this small change.