### PR TITLE
Return _uname_info from the uname_info() method

### DIFF
--- a/distro.py
+++ b/distro.py
@@ -872,6 +872,7 @@ class LinuxDistribution(object):
 
         For details, see :func:`distro.uname_info`.
         """
+        return self._uname_info
 
     def os_release_attr(self, attribute):
         """


### PR DESCRIPTION
Fixes #229

I'm sorry, I don't understand how the test cases work well enough to see why the existing uname_info tests failed to pick up this problem otherwise I would have adapted them to test this case too.  I'm guessing that they test the _uname_info() method directly instead of testing the uname_info() method but I don't quite see where that would be happening.