### PR TITLE
Fixed CloudLinux id discovery

### DIFF
--- a/distro.py
+++ b/distro.py
@@ -1072,7 +1072,10 @@ class LinuxDistribution(object):
             # file), because we want to use what was specified as best as
             # possible.
             match = _DISTRO_RELEASE_BASENAME_PATTERN.match(basename)
-            if match:
+            if 'name' in distro_info \
+               and 'cloudlinux' in distro_info['name'].lower():
+                distro_info['id'] = 'cloudlinux'
+            elif match:
                 distro_info['id'] = match.group(1)
             return distro_info
         else:
@@ -1113,6 +1116,8 @@ class LinuxDistribution(object):
                         # The name is always present if the pattern matches
                         self.distro_release_file = filepath
                         distro_info['id'] = match.group(1)
+                        if 'cloudlinux' in distro_info['name'].lower():
+                            distro_info['id'] = 'cloudlinux'
                         return distro_info
             return {}
 

--- a/tests/test_distro.py
+++ b/tests/test_distro.py
@@ -836,7 +836,7 @@ class TestDistroRelease:
         # Uses redhat-release only to get information.
         # The id of 'rhel' can only be fixed with issue #109.
         desired_outcome = {
-            'id': 'rhel',
+            'id': 'cloudlinux',
             'codename': 'Vladislav Volkov',
             'name': 'CloudLinux Server',
             'pretty_name': 'CloudLinux Server 5.11 (Vladislav Volkov)',
@@ -851,7 +851,7 @@ class TestDistroRelease:
     def test_cloudlinux6_dist_release(self):
         # Same as above, only has redhat-release.
         desired_outcome = {
-            'id': 'rhel',
+            'id': 'cloudlinux',
             'codename': 'Oleg Makarov',
             'name': 'CloudLinux Server',
             'pretty_name': 'CloudLinux Server 6.8 (Oleg Makarov)',
@@ -865,7 +865,7 @@ class TestDistroRelease:
 
     def test_cloudlinux7_dist_release(self):
         desired_outcome = {
-            'id': 'rhel',
+            'id': 'cloudlinux',
             'codename': 'Yury Malyshev',
             'name': 'CloudLinux',
             'pretty_name': 'CloudLinux 7.3 (Yury Malyshev)',
@@ -1486,7 +1486,7 @@ class TestOverall(DistroTestCase):
         # Uses redhat-release only to get information.
         # The id of 'rhel' can only be fixed with issue #109.
         desired_outcome = {
-            'id': 'rhel',
+            'id': 'cloudlinux',
             'codename': 'Vladislav Volkov',
             'name': 'CloudLinux Server',
             'pretty_name': 'CloudLinux Server 5.11 (Vladislav Volkov)',
@@ -1501,7 +1501,7 @@ class TestOverall(DistroTestCase):
     def test_cloudlinux6_release(self):
         # Same as above, only has redhat-release.
         desired_outcome = {
-            'id': 'rhel',
+            'id': 'cloudlinux',
             'codename': 'Oleg Makarov',
             'name': 'CloudLinux Server',
             'pretty_name': 'CloudLinux Server 6.8 (Oleg Makarov)',


### PR DESCRIPTION
CloudLinux 5 and 6 only have redhat-release (making them show up with and id of rhel).
