### PR TITLE
Improve testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,59 @@
-sudo: false
 language: python
+dist: xenial
+
+stages:
+  - lint
+  - test
 
 matrix:
   include:
     - python: 2.7
       env: TOXENV=flake8
-    - python: 3.6
+      stage: lint
+
+    - python: 3.8
       env: TOXENV=py3flake8
+      stage: lint
+
     - python: 2.7
       env: TOXENV=py27
+      stage: test
+
     - python: 3.4
       env: TOXENV=py34
+      dist: trusty
+      stage: test
+
     - python: 3.5
       env: TOXENV=py35
+      stage: test
+
     - python: 3.6
       env: TOXENV=py36
+      stage: test
+
+    - python: 3.7
+      env: TOXENV=py37
+      stage: test
+
+    - python: 3.8
+      env: TOXENV=py38
+      stage: test
+
+    - python: nightly
+      env: TOXENV=py38
+      stage: test
+
     - python: pypy
       env: TOXENV=pypy
-    # This should be tested. Problem is, Travis are using Python 3.2 for pypy3 which is no longer supported by pip
-    # - python: pypy3
-    #   env: TOXENV=pypy3
+      stage: test
+
+    - python: pypy3.5
+      env: TOXENV=pypy35
+      stage: test
+
+  allow_failures:
+    - python: nightly
 
 before_install:
   - pip install codecov

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,8 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: System :: Operating System',
     ]

--- a/tests/test_distro.py
+++ b/tests/test_distro.py
@@ -1618,7 +1618,7 @@ def _bad_os_listdir(path='.'):
     raise OSError()
 
 
-@pytest.mark.skipIf(not IS_LINUX, reason='Irrelevant on non-linx')
+@pytest.mark.skipif(not IS_LINUX, reason='Irrelevant on non-linux')
 class TestOverallWithEtcNotReadable(TestOverall):
     def setup_method(self, test_method):
         self._old_listdir = os.listdir

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@
 
 [tox]
 minversion = 1.7.2
-envlist = flake8, py3flake8, py27, py33, py34, py35, py36, pypy
+envlist = flake8, py3flake8, py27, py3{4,5,6,7,8}, pypy{,35}
 skip_missing_interpreters = true
 
 [testenv]
@@ -37,6 +37,6 @@ deps = flake8
 commands = flake8 distro.py
 
 [testenv:py3flake8]
-basepython = python3.6
+basepython = python3.8
 deps = flake8
 commands = flake8 distro.py


### PR DESCRIPTION
Hello @nir0s,

I believe that it would be nice to have tests for actual and upcoming Python versions.

These changes also:
 - declare support for Python 3.7 and 3.8 at `setup.py`
 - remove Python 3.3 from `tox`'s `envlist`
 - remove [deprecated](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration) `sudo` option from `.travis.yml`
 - fix typos

Best regards!