### PR TITLE
Keep output as native string so we can compatible with python2 interface

### DIFF
--- a/distro.py
+++ b/distro.py
@@ -757,7 +757,7 @@ class LinuxDistribution(object):
                     version = v
                     break
         if pretty and version and self.codename():
-            version = u'{0} ({1})'.format(version, self.codename())
+            version = '{0} ({1})'.format(version, self.codename())
         return version
 
     def version_parts(self, best=False):
@@ -967,8 +967,6 @@ class LinuxDistribution(object):
             # * commands or their arguments (not allowed in os-release)
             if '=' in token:
                 k, v = token.split('=', 1)
-                if isinstance(v, bytes):
-                    v = v.decode('utf-8')
                 props[k.lower()] = v
             else:
                 # Ignore any tokens that are not variable assignments
@@ -1012,7 +1010,7 @@ class LinuxDistribution(object):
                 stdout = subprocess.check_output(cmd, stderr=devnull)
             except OSError:  # Command not found
                 return {}
-        content = stdout.decode(sys.getfilesystemencoding()).splitlines()
+        content = self._to_str(stdout).splitlines()
         return self._parse_lsb_release_content(content)
 
     @staticmethod
@@ -1047,7 +1045,7 @@ class LinuxDistribution(object):
                 stdout = subprocess.check_output(cmd, stderr=devnull)
             except OSError:
                 return {}
-        content = stdout.decode(sys.getfilesystemencoding()).splitlines()
+        content = self._to_str(stdout).splitlines()
         return self._parse_uname_content(content)
 
     @staticmethod
@@ -1066,6 +1064,20 @@ class LinuxDistribution(object):
             props['name'] = name
             props['release'] = version
         return props
+
+    @staticmethod
+    def _to_str(text):
+        encoding = sys.getfilesystemencoding()
+        encoding = 'utf-8' if encoding == 'ascii' else encoding
+
+        if sys.version_info[0] >= 3:
+            if isinstance(text, bytes):
+                return text.decode(encoding)
+        else:
+            if isinstance(text, unicode):  # noqa
+                return text.encode(encoding)
+
+        return text
 
     @cached_property
     def _distro_release_info(self):
@@ -1169,8 +1181,6 @@ class LinuxDistribution(object):
         Returns:
             A dictionary containing all information items.
         """
-        if isinstance(line, bytes):
-            line = line.decode('utf-8')
         matches = _DISTRO_RELEASE_CONTENT_REVERSED_PATTERN.match(
             line.strip()[::-1])
         distro_info = {}

--- a/tests/test_distro.py
+++ b/tests/test_distro.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 # Copyright 2015,2016 Nir Cohen
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -191,11 +192,11 @@ class TestOSRelease:
         desired_outcome = {
             'id': 'fedora',
             'name': 'Fedora',
-            'pretty_name': u'Fedora 19 (Schr\u00F6dinger\u2019s Cat)',
+            'pretty_name': 'Fedora 19 (Schrödinger’s Cat)',
             'version': '19',
-            'pretty_version': u'19 (Schr\u00F6dinger\u2019s Cat)',
+            'pretty_version': '19 (Schrödinger’s Cat)',
             'best_version': '19',
-            'codename': u'Schr\u00F6dinger\u2019s Cat'
+            'codename': 'Schrödinger’s Cat'
         }
         self._test_outcome(desired_outcome)
 
@@ -703,11 +704,11 @@ class TestDistroRelease:
         desired_outcome = {
             'id': 'fedora',
             'name': 'Fedora',
-            'pretty_name': u'Fedora 19 (Schr\u00F6dinger\u2019s Cat)',
+            'pretty_name': 'Fedora 19 (Schrödinger’s Cat)',
             'version': '19',
-            'pretty_version': u'19 (Schr\u00F6dinger\u2019s Cat)',
+            'pretty_version': '19 (Schrödinger’s Cat)',
             'best_version': '19',
-            'codename': u'Schr\u00F6dinger\u2019s Cat',
+            'codename': 'Schrödinger’s Cat',
             'major_version': '19'
         }
         self._test_outcome(desired_outcome, 'fedora', '19')
@@ -1078,11 +1079,11 @@ class TestOverall(DistroTestCase):
         desired_outcome = {
             'id': 'fedora',
             'name': 'Fedora',
-            'pretty_name': u'Fedora 19 (Schr\u00F6dinger\u2019s Cat)',
+            'pretty_name': 'Fedora 19 (Schrödinger’s Cat)',
             'version': '19',
-            'pretty_version': u'19 (Schr\u00F6dinger\u2019s Cat)',
+            'pretty_version': '19 (Schrödinger’s Cat)',
             'best_version': '19',
-            'codename': u'Schr\u00F6dinger\u2019s Cat',
+            'codename': 'Schrödinger’s Cat',
             'major_version': '19'
         }
         self._test_outcome(desired_outcome)
@@ -1091,7 +1092,7 @@ class TestOverall(DistroTestCase):
             'id': 'fedora',
             'name': 'Fedora',
             'version_id': '19',
-            'codename': u'Schr\u00F6dinger\u2019s Cat'
+            'codename': 'Schrödinger’s Cat'
         }
         self._test_release_file_info('fedora-release', desired_info)
 
@@ -1618,7 +1619,7 @@ def _bad_os_listdir(path='.'):
     raise OSError()
 
 
-@pytest.mark.skipIf(not IS_LINUX, reason='Irrelevant on non-linx')
+@pytest.mark.skipif(not IS_LINUX, reason='Irrelevant on non-linx')
 class TestOverallWithEtcNotReadable(TestOverall):
     def setup_method(self, test_method):
         self._old_listdir = os.listdir
@@ -2060,3 +2061,20 @@ class TestRepr:
         assert "LinuxDistribution" in repr_str
         for attr in MODULE_DISTRO.__dict__.keys():
             assert attr + '=' in repr_str
+
+
+@pytest.mark.skipif(not IS_LINUX, reason='Irrelevant on non-linux')
+class TestToStr:
+    """Test the _to_str() method.
+    """
+
+    def test_to_str(self):
+        ret = distro.LinuxDistribution._to_str(b'bytes')
+        assert isinstance(ret, str)
+        assert ret == 'bytes'
+
+        ret = distro.LinuxDistribution._to_str(u'bytes')
+        assert isinstance(ret, str)
+
+        ret = distro.LinuxDistribution._to_str('bytes')
+        assert isinstance(ret, str)


### PR DESCRIPTION
since `platform.linux_distribution()` returns tuple of str， we should compatible with the same behavior on both python2 and python3.

1. open() return string on both python2 and python3, just keep it.
2. stdout of Popen() return string on python2, and bytes on python3,
    decode to string.