### PR TITLE
Fix Oracle 4/5 lsb_release id and names

### DIFF
--- a/distro.py
+++ b/distro.py
@@ -60,7 +60,8 @@ NORMALIZED_OS_ID = {
 #:
 #: * Value: Normalized value.
 NORMALIZED_LSB_ID = {
-    'enterpriseenterprise': 'oracle',  # Oracle Linux
+    'enterpriseenterpriseas': 'oracle',  # Oracle Enterprise Linux 4
+    'enterpriseenterpriseserver': 'oracle',  # Oracle Linux 5
     'redhatenterpriseworkstation': 'rhel',  # RHEL 6, 7 Workstation
     'redhatenterpriseserver': 'rhel',  # RHEL 6, 7 Server
 }

--- a/distro.py
+++ b/distro.py
@@ -49,7 +49,7 @@ _OS_RELEASE_BASENAME = 'os-release'
 #:
 #: * Value: Normalized value.
 NORMALIZED_OS_ID = {
-    'ol': 'oracle',  # Oracle Enterprise Linux
+    'ol': 'oracle',  # Oracle Linux
 }
 
 #: Translation table for normalizing the "Distributor ID" attribute returned by
@@ -60,7 +60,7 @@ NORMALIZED_OS_ID = {
 #:
 #: * Value: Normalized value.
 NORMALIZED_LSB_ID = {
-    'enterpriseenterprise': 'oracle',  # Oracle Enterprise Linux
+    'enterpriseenterprise': 'oracle',  # Oracle Linux
     'redhatenterpriseworkstation': 'rhel',  # RHEL 6, 7 Workstation
     'redhatenterpriseserver': 'rhel',  # RHEL 6, 7 Server
 }


### PR DESCRIPTION
See #239 
Unfortunately this doesn't resolve all cases mentioned in #239 (Oracle Linux 6.1 is still not recognized correctly) but it will fix Oracle Linux 4 and 5.