### PR TITLE
Fix detection of RHEL 6 ComputeNode

### DIFF
--- a/distro.py
+++ b/distro.py
@@ -63,7 +63,7 @@ NORMALIZED_LSB_ID = {
     'enterpriseenterprise': 'oracle',  # Oracle Enterprise Linux
     'redhatenterpriseworkstation': 'rhel',  # RHEL 6, 7 Workstation
     'redhatenterpriseserver': 'rhel',  # RHEL 6, 7 Server
-    'redhatenterprisecomputenode': 'rhel',  # RHEL 6 Compute Node
+    'redhatenterprisecomputenode': 'rhel',  # RHEL 6 ComputeNode
 }
 
 #: Translation table for normalizing the distro ID derived from the file name

--- a/distro.py
+++ b/distro.py
@@ -63,6 +63,7 @@ NORMALIZED_LSB_ID = {
     'enterpriseenterprise': 'oracle',  # Oracle Enterprise Linux
     'redhatenterpriseworkstation': 'rhel',  # RHEL 6, 7 Workstation
     'redhatenterpriseserver': 'rhel',  # RHEL 6, 7 Server
+    'redhatenterprisecomputenode': 'rhel',  # RHEL 6 Compute Node
 }
 
 #: Translation table for normalizing the distro ID derived from the file name


### PR DESCRIPTION
This PR fixes detection of RHEL 6 ComputeNode.

This bug was originally reported by @CreRecombinase in https://github.com/spack/spack/issues/15251 and fixed in Spack's vendored copy of `distro` in https://github.com/spack/spack/pull/15253

Let me know if you want me to add unit tests for this. https://github.com/spack/spack/issues/15251 has the output of `lsb_release -a` for the problematic nodes.