### PR TITLE
Pass CLI positional argument through to pytest

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ skip_missing_interpreters = true
 deps =
     pytest
     pytest-cov
-commands = pytest --cov-report term-missing --cov distro
+commands = pytest --cov-report term-missing --cov distro {posargs}
 
 [testenv:lint]
 deps = pre-commit


### PR DESCRIPTION
A development convenience to pass arguments like -v -x and others.

See:
https://tox.wiki/en/latest/config.html#substitutions-for-positional-arguments-in-commands