### PR TITLE
Run mypy on all files including tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,4 +17,7 @@ repos:
     hooks:
       - id: mypy
         args: ["--strict"]
-        files: ^distro\.py$
+        additional_dependencies: [
+            "pytest==6.2.5",
+            "types-setuptools==57.4.2",
+        ]

--- a/query_local_distro.py
+++ b/query_local_distro.py
@@ -18,7 +18,7 @@ from pprint import pformat
 import distro
 
 
-def pprint(obj):
+def pprint(obj: object) -> None:
     for line in pformat(obj).split("\n"):
         print(4 * " " + line)
 

--- a/tests/test_distro.py
+++ b/tests/test_distro.py
@@ -18,6 +18,8 @@ import json
 import os
 import subprocess
 import sys
+from types import FunctionType
+from typing import Any, Dict, List, NoReturn, Optional
 
 import pytest
 
@@ -39,7 +41,7 @@ if IS_LINUX:
 
 
 class TestNonLinuxPlatform:
-    def test_cant_use_on_windows(self):
+    def test_cant_use_on_windows(self) -> None:
         try:
             import distro  # NOQA
         except ImportError as ex:
@@ -48,11 +50,11 @@ class TestNonLinuxPlatform:
 
 @pytest.mark.skipif(not IS_LINUX, reason="Irrelevant on non-linux")
 class TestCli:
-    def _parse(self, command):
+    def _parse(self, command: str) -> None:
         sys.argv = command.split()
         distro.main()
 
-    def _run(self, command):
+    def _run(self, command: List[str]) -> str:
         r = subprocess.run(
             command,
             stdout=subprocess.PIPE,
@@ -61,15 +63,15 @@ class TestCli:
         )
         return r.stdout
 
-    def test_cli_for_coverage_yuch(self):
+    def test_cli_for_coverage_yuch(self) -> None:
         self._parse("distro")
         self._parse("distro -j")
 
-    def test_cli_can_parse_root_dir_args(self):
+    def test_cli_can_parse_root_dir_args(self) -> None:
         root_dir = os.path.join(RESOURCES, "cli", "fedora30")
         self._parse(f"distro --root-dir {root_dir}")
 
-    def test_cli(self):
+    def test_cli(self) -> None:
         command = [sys.executable, "-m", "distro"]
         desired_output = f"Name: {distro.name(pretty=True)}"
         distro_version = distro.version(pretty=True)
@@ -79,17 +81,17 @@ class TestCli:
         desired_output += "\n"
         assert self._run(command) == desired_output
 
-    def test_cli_json(self):
+    def test_cli_json(self) -> None:
         command = [sys.executable, "-m", "distro", "-j"]
         assert ast.literal_eval(self._run(command)) == distro.info()
 
-    def test_cli_with_root_dir(self):
+    def test_cli_with_root_dir(self) -> None:
         root_dir = os.path.join(RESOURCES, "cli", "fedora30")
         command = [sys.executable, "-m", "distro", "--root-dir", root_dir]
         desired_output = "Name: Fedora 30 (Thirty)\nVersion: 30\nCodename: \n"
         assert desired_output == self._run(command)
 
-    def test_cli_with_root_dir_as_json(self):
+    def test_cli_with_root_dir_as_json(self) -> None:
         root_dir = os.path.join(RESOURCES, "cli", "fedora30")
         command = [sys.executable, "-m", "distro", "-j", "--root-dir", root_dir]
         desired_output = {
@@ -110,7 +112,7 @@ class DistroTestCase:
     represented in the `DISTROS` subtree.
     """
 
-    def setup_method(self, test_method):
+    def setup_method(self, test_method: FunctionType) -> None:
         # The environment stays the same across all testcases, so we
         # save and restore the PATH env var in each test case that
         # changes it:
@@ -118,12 +120,12 @@ class DistroTestCase:
         self._saved_UNIXCONFDIR = distro._UNIXCONFDIR
         self._saved_UNIXUSRLIBDIR = distro._UNIXUSRLIBDIR
 
-    def teardown_method(self, test_method):
+    def teardown_method(self, test_method: FunctionType) -> None:
         os.environ["PATH"] = self._saved_path
         distro._UNIXCONFDIR = self._saved_UNIXCONFDIR
         distro._UNIXUSRLIBDIR = self._saved_UNIXUSRLIBDIR
 
-    def _setup_for_distro(self, distro_root):
+    def _setup_for_distro(self, distro_root: str) -> None:
         distro_bin = os.path.join(distro_root, "bin")
         # We don't want to pick up a possibly present lsb_release in the
         # distro that runs this test, so we use a PATH with only one entry:
@@ -134,7 +136,7 @@ class DistroTestCase:
 
 @pytest.mark.skipif(not IS_LINUX, reason="Irrelevant on non-linux")
 class TestOSRelease:
-    def setup_method(self, test_method):
+    def setup_method(self, test_method: FunctionType) -> None:
         dist = test_method.__name__.split("_")[1]
         os_release = os.path.join(DISTROS_DIR, dist, "etc", "os-release")
         self.distro = distro.LinuxDistribution(
@@ -143,7 +145,7 @@ class TestOSRelease:
             distro_release_file="path-to-non-existing-file",
         )
 
-    def _test_outcome(self, outcome):
+    def _test_outcome(self, outcome: Dict[str, str]) -> None:
         assert self.distro.id() == outcome.get("id", "")
         assert self.distro.name() == outcome.get("name", "")
         assert self.distro.name(pretty=True) == outcome.get("pretty_name", "")
@@ -153,7 +155,7 @@ class TestOSRelease:
         assert self.distro.like() == outcome.get("like", "")
         assert self.distro.codename() == outcome.get("codename", "")
 
-    def test_arch_os_release(self):
+    def test_arch_os_release(self) -> None:
         desired_outcome = {
             "id": "arch",
             "name": "Arch Linux",
@@ -161,7 +163,7 @@ class TestOSRelease:
         }
         self._test_outcome(desired_outcome)
 
-    def test_kali_os_release(self):
+    def test_kali_os_release(self) -> None:
         desired_outcome = {
             "id": "kali",
             "name": "Kali GNU/Linux",
@@ -173,7 +175,7 @@ class TestOSRelease:
         }
         self._test_outcome(desired_outcome)
 
-    def test_centos7_os_release(self):
+    def test_centos7_os_release(self) -> None:
         desired_outcome = {
             "id": "centos",
             "name": "CentOS Linux",
@@ -186,7 +188,7 @@ class TestOSRelease:
         }
         self._test_outcome(desired_outcome)
 
-    def test_coreos_os_release(self):
+    def test_coreos_os_release(self) -> None:
         desired_outcome = {
             "id": "coreos",
             "name": "CoreOS",
@@ -197,7 +199,7 @@ class TestOSRelease:
         }
         self._test_outcome(desired_outcome)
 
-    def test_debian8_os_release(self):
+    def test_debian8_os_release(self) -> None:
         desired_outcome = {
             "id": "debian",
             "name": "Debian GNU/Linux",
@@ -209,7 +211,7 @@ class TestOSRelease:
         }
         self._test_outcome(desired_outcome)
 
-    def test_fedora19_os_release(self):
+    def test_fedora19_os_release(self) -> None:
         desired_outcome = {
             "id": "fedora",
             "name": "Fedora",
@@ -221,7 +223,7 @@ class TestOSRelease:
         }
         self._test_outcome(desired_outcome)
 
-    def test_fedora23_os_release(self):
+    def test_fedora23_os_release(self) -> None:
         desired_outcome = {
             "id": "fedora",
             "name": "Fedora",
@@ -233,7 +235,7 @@ class TestOSRelease:
         }
         self._test_outcome(desired_outcome)
 
-    def test_fedora30_os_release(self):
+    def test_fedora30_os_release(self) -> None:
         # Fedora 21 and above no longer have code names but the metadata in
         # os-release was only changed in a detectable way in Fedora 30+. The
         # piece in parenthesis in the pretty_name field contains the VARIANT
@@ -249,7 +251,7 @@ class TestOSRelease:
         }
         self._test_outcome(desired_outcome)
 
-    def test_kvmibm1_os_release(self):
+    def test_kvmibm1_os_release(self) -> None:
         desired_outcome = {
             "id": "kvmibm",
             "name": "KVM for IBM z Systems",
@@ -262,7 +264,7 @@ class TestOSRelease:
         }
         self._test_outcome(desired_outcome)
 
-    def test_linuxmint17_os_release(self):
+    def test_linuxmint17_os_release(self) -> None:
         # Note: LinuxMint 17 actually *does* have Ubuntu 14.04 data in its
         #       os-release file. See discussion in GitHub issue #78.
         desired_outcome = {
@@ -277,7 +279,7 @@ class TestOSRelease:
         }
         self._test_outcome(desired_outcome)
 
-    def test_mageia5_os_release(self):
+    def test_mageia5_os_release(self) -> None:
         desired_outcome = {
             "id": "mageia",
             "name": "Mageia",
@@ -289,12 +291,12 @@ class TestOSRelease:
         }
         self._test_outcome(desired_outcome)
 
-    def test_manjaro1512_os_release(self):
+    def test_manjaro1512_os_release(self) -> None:
         self._test_outcome(
             {"id": "manjaro", "name": "Manjaro Linux", "pretty_name": "Manjaro Linux"}
         )
 
-    def test_opensuse42_os_release(self):
+    def test_opensuse42_os_release(self) -> None:
         desired_outcome = {
             "id": "opensuse",
             "name": "openSUSE Leap",
@@ -306,7 +308,7 @@ class TestOSRelease:
         }
         self._test_outcome(desired_outcome)
 
-    def test_raspbian7_os_release(self):
+    def test_raspbian7_os_release(self) -> None:
         desired_outcome = {
             "id": "raspbian",
             "name": "Raspbian GNU/Linux",
@@ -319,7 +321,7 @@ class TestOSRelease:
         }
         self._test_outcome(desired_outcome)
 
-    def test_raspbian8_os_release(self):
+    def test_raspbian8_os_release(self) -> None:
         desired_outcome = {
             "id": "raspbian",
             "name": "Raspbian GNU/Linux",
@@ -332,7 +334,7 @@ class TestOSRelease:
         }
         self._test_outcome(desired_outcome)
 
-    def test_rhel7_os_release(self):
+    def test_rhel7_os_release(self) -> None:
         desired_outcome = {
             "id": "rhel",
             "name": "Red Hat Enterprise Linux Server",
@@ -345,7 +347,7 @@ class TestOSRelease:
         }
         self._test_outcome(desired_outcome)
 
-    def test_slackware14_os_release(self):
+    def test_slackware14_os_release(self) -> None:
         desired_outcome = {
             "id": "slackware",
             "name": "Slackware",
@@ -356,7 +358,7 @@ class TestOSRelease:
         }
         self._test_outcome(desired_outcome)
 
-    def test_sles12_os_release(self):
+    def test_sles12_os_release(self) -> None:
         desired_outcome = {
             "id": "sles",
             "name": "SLES",
@@ -367,7 +369,7 @@ class TestOSRelease:
         }
         self._test_outcome(desired_outcome)
 
-    def test_ubuntu14_os_release(self):
+    def test_ubuntu14_os_release(self) -> None:
         desired_outcome = {
             "id": "ubuntu",
             "name": "Ubuntu",
@@ -380,7 +382,7 @@ class TestOSRelease:
         }
         self._test_outcome(desired_outcome)
 
-    def test_ubuntu16_os_release(self):
+    def test_ubuntu16_os_release(self) -> None:
         desired_outcome = {
             "id": "ubuntu",
             "name": "Ubuntu",
@@ -393,7 +395,7 @@ class TestOSRelease:
         }
         self._test_outcome(desired_outcome)
 
-    def test_amazon2016_os_release(self):
+    def test_amazon2016_os_release(self) -> None:
         desired_outcome = {
             "id": "amzn",
             "name": "Amazon Linux AMI",
@@ -405,7 +407,7 @@ class TestOSRelease:
         }
         self._test_outcome(desired_outcome)
 
-    def test_scientific7_os_release(self):
+    def test_scientific7_os_release(self) -> None:
         desired_outcome = {
             "id": "rhel",
             "name": "Scientific Linux",
@@ -418,7 +420,7 @@ class TestOSRelease:
         }
         self._test_outcome(desired_outcome)
 
-    def test_gentoo_os_release(self):
+    def test_gentoo_os_release(self) -> None:
         desired_outcome = {
             "id": "gentoo",
             "name": "Gentoo",
@@ -426,7 +428,7 @@ class TestOSRelease:
         }
         self._test_outcome(desired_outcome)
 
-    def test_openelec6_os_release(self):
+    def test_openelec6_os_release(self) -> None:
         desired_outcome = {
             "id": "openelec",
             "name": "OpenELEC",
@@ -437,7 +439,7 @@ class TestOSRelease:
         }
         self._test_outcome(desired_outcome)
 
-    def test_cloudlinux7_os_release(self):
+    def test_cloudlinux7_os_release(self) -> None:
         desired_outcome = {
             "id": "cloudlinux",
             "codename": "Yury Malyshev",
@@ -458,7 +460,7 @@ class TestWithRootDir(TestOSRelease):
     on all OSes.
     """
 
-    def setup_method(self, test_method):
+    def setup_method(self, test_method: FunctionType) -> None:
         dist = test_method.__name__.split("_")[1]
         root_dir = os.path.join(DISTROS_DIR, dist)
         self.distro = distro.LinuxDistribution(
@@ -472,7 +474,7 @@ class TestWithRootDir(TestOSRelease):
 
 @pytest.mark.skipif(not IS_LINUX, reason="Irrelevant on non-linux")
 class TestLSBRelease(DistroTestCase):
-    def setup_method(self, test_method):
+    def setup_method(self, test_method: FunctionType) -> None:
         super().setup_method(test_method)
         dist = test_method.__name__.split("_")[1]
         self._setup_for_distro(os.path.join(DISTROS_DIR, dist))
@@ -482,7 +484,7 @@ class TestLSBRelease(DistroTestCase):
             distro_release_file="path-to-non-existing-file",
         )
 
-    def _test_outcome(self, outcome):
+    def _test_outcome(self, outcome: Dict[str, str]) -> None:
         assert self.distro.id() == outcome.get("id", "")
         assert self.distro.name() == outcome.get("name", "")
         assert self.distro.name(pretty=True) == outcome.get("pretty_name", "")
@@ -492,7 +494,7 @@ class TestLSBRelease(DistroTestCase):
         assert self.distro.like() == outcome.get("like", "")
         assert self.distro.codename() == outcome.get("codename", "")
 
-    def test_linuxmint17_lsb_release(self):
+    def test_linuxmint17_lsb_release(self) -> None:
         desired_outcome = {
             "id": "linuxmint",
             "name": "LinuxMint",
@@ -504,7 +506,7 @@ class TestLSBRelease(DistroTestCase):
         }
         self._test_outcome(desired_outcome)
 
-    def test_manjaro1512_lsb_release(self):
+    def test_manjaro1512_lsb_release(self) -> None:
         self._test_outcome(
             {
                 "id": "manjarolinux",
@@ -518,7 +520,7 @@ class TestLSBRelease(DistroTestCase):
         )
 
     # @pytest.mark.xfail
-    # def test_openelec6_lsb_release(self):
+    # def test_openelec6_lsb_release(self) -> None:
     #     # TODO: This should be fixed as part of #109 when dealing
     #     # with distro inconsistencies
     #     desired_outcome = {
@@ -531,7 +533,7 @@ class TestLSBRelease(DistroTestCase):
     #     }
     #     self._test_outcome(desired_outcome)
 
-    def test_openbsd62_uname(self):
+    def test_openbsd62_uname(self) -> None:
         self._test_outcome(
             {
                 "id": "openbsd",
@@ -543,7 +545,7 @@ class TestLSBRelease(DistroTestCase):
             }
         )
 
-    def test_netbsd711_uname(self):
+    def test_netbsd711_uname(self) -> None:
         self._test_outcome(
             {
                 "id": "netbsd",
@@ -555,7 +557,7 @@ class TestLSBRelease(DistroTestCase):
             }
         )
 
-    def test_freebsd111_uname(self):
+    def test_freebsd111_uname(self) -> None:
         self._test_outcome(
             {
                 "id": "freebsd",
@@ -567,7 +569,7 @@ class TestLSBRelease(DistroTestCase):
             }
         )
 
-    def test_midnightbsd12_uname(self):
+    def test_midnightbsd12_uname(self) -> None:
         self._test_outcome(
             {
                 "id": "midnightbsd",
@@ -579,7 +581,7 @@ class TestLSBRelease(DistroTestCase):
             }
         )
 
-    def test_ubuntu14normal_lsb_release(self):
+    def test_ubuntu14normal_lsb_release(self) -> None:
         self._setup_for_distro(os.path.join(TESTDISTROS, "lsb", "ubuntu14_normal"))
 
         self.distro = distro.LinuxDistribution(
@@ -599,7 +601,7 @@ class TestLSBRelease(DistroTestCase):
         }
         self._test_outcome(desired_outcome)
 
-    def test_ubuntu14nomodules_lsb_release(self):
+    def test_ubuntu14nomodules_lsb_release(self) -> None:
         self._setup_for_distro(os.path.join(TESTDISTROS, "lsb", "ubuntu14_nomodules"))
 
         self.distro = distro.LinuxDistribution(
@@ -619,7 +621,7 @@ class TestLSBRelease(DistroTestCase):
         }
         self._test_outcome(desired_outcome)
 
-    def test_trailingblanks_lsb_release(self):
+    def test_trailingblanks_lsb_release(self) -> None:
         self._setup_for_distro(
             os.path.join(TESTDISTROS, "lsb", "ubuntu14_trailingblanks")
         )
@@ -642,7 +644,7 @@ class TestLSBRelease(DistroTestCase):
         self._test_outcome(desired_outcome)
 
     @pytest.mark.parametrize("errnum", ("001", "002", "126", "130", "255"))
-    def test_lsb_release_error_level(self, errnum):
+    def test_lsb_release_error_level(self, errnum: str) -> None:
         self._setup_for_distro(os.path.join(TESTDISTROS, "lsb", f"lsb_rc{errnum}"))
 
         lsb_release_info = distro.LinuxDistribution(
@@ -656,7 +658,7 @@ class TestLSBRelease(DistroTestCase):
 
 @pytest.mark.skipif(not IS_LINUX, reason="Irrelevant on non-linux")
 class TestSpecialRelease(DistroTestCase):
-    def _test_outcome(self, outcome):
+    def _test_outcome(self, outcome: Dict[str, str]) -> None:
         assert self.distro.id() == outcome.get("id", "")
         assert self.distro.name() == outcome.get("name", "")
         assert self.distro.name(pretty=True) == outcome.get("pretty_name", "")
@@ -669,7 +671,7 @@ class TestSpecialRelease(DistroTestCase):
         assert self.distro.minor_version() == outcome.get("minor_version", "")
         assert self.distro.build_number() == outcome.get("build_number", "")
 
-    def test_empty_release(self):
+    def test_empty_release(self) -> None:
         distro_release = os.path.join(SPECIAL, "empty-release")
 
         self.distro = distro.LinuxDistribution(
@@ -681,7 +683,7 @@ class TestSpecialRelease(DistroTestCase):
         desired_outcome = {"id": "empty"}
         self._test_outcome(desired_outcome)
 
-    def test_dontincludeuname(self):
+    def test_dontincludeuname(self) -> None:
         self._setup_for_distro(os.path.join(TESTDISTROS, "distro", "dontincludeuname"))
 
         self.distro = distro.LinuxDistribution(include_uname=False)
@@ -690,7 +692,7 @@ class TestSpecialRelease(DistroTestCase):
         assert self.distro.uname_attr("name") == ""
         assert self.distro.uname_attr("release") == ""
 
-    def test_unknowndistro_release(self):
+    def test_unknowndistro_release(self) -> None:
         self._setup_for_distro(os.path.join(TESTDISTROS, "distro", "unknowndistro"))
 
         self.distro = distro.LinuxDistribution()
@@ -708,7 +710,7 @@ class TestSpecialRelease(DistroTestCase):
         }
         self._test_outcome(desired_outcome)
 
-    def test_bad_uname(self):
+    def test_bad_uname(self) -> None:
         self._setup_for_distro(os.path.join(TESTDISTROS, "distro", "baduname"))
         self.distro = distro.LinuxDistribution()
 
@@ -716,7 +718,7 @@ class TestSpecialRelease(DistroTestCase):
         assert self.distro.uname_attr("name") == ""
         assert self.distro.uname_attr("release") == ""
 
-    def test_empty_uname(self):
+    def test_empty_uname(self) -> None:
         self._setup_for_distro(os.path.join(TESTDISTROS, "distro", "emptyuname"))
         self.distro = distro.LinuxDistribution()
 
@@ -724,7 +726,7 @@ class TestSpecialRelease(DistroTestCase):
         assert self.distro.uname_attr("name") == ""
         assert self.distro.uname_attr("release") == ""
 
-    def test_usrlibosreleaseonly(self):
+    def test_usrlibosreleaseonly(self) -> None:
         self._setup_for_distro(
             os.path.join(TESTDISTROS, "distro", "usrlibosreleaseonly")
         )
@@ -742,12 +744,12 @@ class TestSpecialRelease(DistroTestCase):
 class TestDistroRelease:
     def _test_outcome(
         self,
-        outcome,
-        distro_name="",
-        version="",
-        release_file_id="",
-        release_file_suffix="release",
-    ):
+        outcome: Dict[str, str],
+        distro_name: str = "",
+        version: str = "",
+        release_file_id: str = "",
+        release_file_suffix: str = "release",
+    ) -> None:
         release_file_id = release_file_id or distro_name
         distro_release = os.path.join(
             DISTROS_DIR,
@@ -773,11 +775,11 @@ class TestDistroRelease:
         assert self.distro.minor_version() == outcome.get("minor_version", "")
         assert self.distro.build_number() == outcome.get("build_number", "")
 
-    def test_arch_dist_release(self):
+    def test_arch_dist_release(self) -> None:
         desired_outcome = {"id": "arch"}
         self._test_outcome(desired_outcome, "arch")
 
-    def test_centos5_dist_release(self):
+    def test_centos5_dist_release(self) -> None:
         desired_outcome = {
             "id": "centos",
             "name": "CentOS",
@@ -791,7 +793,7 @@ class TestDistroRelease:
         }
         self._test_outcome(desired_outcome, "centos", "5")
 
-    def test_centos7_dist_release(self):
+    def test_centos7_dist_release(self) -> None:
         desired_outcome = {
             "id": "centos",
             "name": "CentOS Linux",
@@ -806,7 +808,7 @@ class TestDistroRelease:
         }
         self._test_outcome(desired_outcome, "centos", "7")
 
-    def test_fedora19_dist_release(self):
+    def test_fedora19_dist_release(self) -> None:
         desired_outcome = {
             "id": "fedora",
             "name": "Fedora",
@@ -819,7 +821,7 @@ class TestDistroRelease:
         }
         self._test_outcome(desired_outcome, "fedora", "19")
 
-    def test_fedora23_dist_release(self):
+    def test_fedora23_dist_release(self) -> None:
         desired_outcome = {
             "id": "fedora",
             "name": "Fedora",
@@ -832,7 +834,7 @@ class TestDistroRelease:
         }
         self._test_outcome(desired_outcome, "fedora", "23")
 
-    def test_fedora30_dist_release(self):
+    def test_fedora30_dist_release(self) -> None:
         desired_outcome = {
             "id": "fedora",
             "name": "Fedora",
@@ -845,7 +847,7 @@ class TestDistroRelease:
         }
         self._test_outcome(desired_outcome, "fedora", "30")
 
-    def test_gentoo_dist_release(self):
+    def test_gentoo_dist_release(self) -> None:
         desired_outcome = {
             "id": "gentoo",
             "name": "Gentoo Base System",
@@ -858,7 +860,7 @@ class TestDistroRelease:
         }
         self._test_outcome(desired_outcome, "gentoo")
 
-    def test_kvmibm1_dist_release(self):
+    def test_kvmibm1_dist_release(self) -> None:
         desired_outcome = {
             "id": "base",
             "name": "KVM for IBM z Systems",
@@ -873,7 +875,7 @@ class TestDistroRelease:
         }
         self._test_outcome(desired_outcome, "kvmibm", "1", "base")
 
-    def test_mageia5_dist_release(self):
+    def test_mageia5_dist_release(self) -> None:
         desired_outcome = {
             "id": "mageia",
             "name": "Mageia",
@@ -886,7 +888,7 @@ class TestDistroRelease:
         }
         self._test_outcome(desired_outcome, "mageia", "5")
 
-    def test_manjaro1512_dist_release(self):
+    def test_manjaro1512_dist_release(self) -> None:
         self._test_outcome(
             {
                 "id": "manjaro",
@@ -899,7 +901,7 @@ class TestDistroRelease:
             "1512",
         )
 
-    def test_opensuse42_dist_release(self):
+    def test_opensuse42_dist_release(self) -> None:
         desired_outcome = {
             "id": "suse",
             "name": "openSUSE",
@@ -913,7 +915,7 @@ class TestDistroRelease:
         }
         self._test_outcome(desired_outcome, "opensuse", "42", "SuSE")
 
-    def test_oracle7_dist_release(self):
+    def test_oracle7_dist_release(self) -> None:
         desired_outcome = {
             "id": "oracle",
             "name": "Oracle Linux Server",
@@ -926,7 +928,7 @@ class TestDistroRelease:
         }
         self._test_outcome(desired_outcome, "oracle", "7")
 
-    def test_rhel6_dist_release(self):
+    def test_rhel6_dist_release(self) -> None:
         desired_outcome = {
             "id": "rhel",
             "name": "Red Hat Enterprise Linux Server",
@@ -940,7 +942,7 @@ class TestDistroRelease:
         }
         self._test_outcome(desired_outcome, "rhel", "6", "redhat")
 
-    def test_rhel7_dist_release(self):
+    def test_rhel7_dist_release(self) -> None:
         desired_outcome = {
             "id": "rhel",
             "name": "Red Hat Enterprise Linux Server",
@@ -954,7 +956,7 @@ class TestDistroRelease:
         }
         self._test_outcome(desired_outcome, "rhel", "7", "redhat")
 
-    def test_slackware14_dist_release(self):
+    def test_slackware14_dist_release(self) -> None:
         desired_outcome = {
             "id": "slackware",
             "name": "Slackware",
@@ -969,7 +971,7 @@ class TestDistroRelease:
             desired_outcome, "slackware", "14", release_file_suffix="version"
         )
 
-    def test_sles12_dist_release(self):
+    def test_sles12_dist_release(self) -> None:
         desired_outcome = {
             "id": "suse",
             "name": "SUSE Linux Enterprise Server",
@@ -982,7 +984,7 @@ class TestDistroRelease:
         }
         self._test_outcome(desired_outcome, "sles", "12", "SuSE")
 
-    def test_cloudlinux5_dist_release(self):
+    def test_cloudlinux5_dist_release(self) -> None:
         # Uses redhat-release only to get information.
         # The id of 'rhel' can only be fixed with issue #109.
         desired_outcome = {
@@ -998,7 +1000,7 @@ class TestDistroRelease:
         }
         self._test_outcome(desired_outcome, "cloudlinux", "5", "redhat")
 
-    def test_cloudlinux6_dist_release(self):
+    def test_cloudlinux6_dist_release(self) -> None:
         # Same as above, only has redhat-release.
         desired_outcome = {
             "id": "cloudlinux",
@@ -1013,7 +1015,7 @@ class TestDistroRelease:
         }
         self._test_outcome(desired_outcome, "cloudlinux", "6", "redhat")
 
-    def test_cloudlinux7_dist_release(self):
+    def test_cloudlinux7_dist_release(self) -> None:
         desired_outcome = {
             "id": "cloudlinux",
             "codename": "Yury Malyshev",
@@ -1054,13 +1056,13 @@ class TestOverall(DistroTestCase):
       * `xenserver` - XenServer
     """
 
-    def setup_method(self, test_method):
+    def setup_method(self, test_method: FunctionType) -> None:
         super().setup_method(test_method)
         dist = test_method.__name__.split("_")[1]
         self._setup_for_distro(os.path.join(DISTROS_DIR, dist))
         self.distro = distro.LinuxDistribution()
 
-    def _test_outcome(self, outcome):
+    def _test_outcome(self, outcome: Dict[str, str]) -> None:
         assert self.distro.id() == outcome.get("id", "")
         assert self.distro.name() == outcome.get("name", "")
         assert self.distro.name(pretty=True) == outcome.get("pretty_name", "")
@@ -1073,13 +1075,15 @@ class TestOverall(DistroTestCase):
         assert self.distro.minor_version() == outcome.get("minor_version", "")
         assert self.distro.build_number() == outcome.get("build_number", "")
 
-    def _test_non_existing_release_file(self):
+    def _test_non_existing_release_file(self) -> None:
         # Test the info from the searched distro release file
         # does not have one.
         assert self.distro.distro_release_file == ""
         assert len(self.distro.distro_release_info()) == 0
 
-    def _test_release_file_info(self, filename, outcome):
+    def _test_release_file_info(
+        self, filename: str, outcome: Dict[str, str]
+    ) -> Dict[str, str]:
         # Test the info from the searched distro release file
         assert os.path.basename(self.distro.distro_release_file) == filename
         distro_info = self.distro.distro_release_info()
@@ -1087,7 +1091,7 @@ class TestOverall(DistroTestCase):
             assert distro_info[key] == value
         return distro_info
 
-    def test_arch_release(self):
+    def test_arch_release(self) -> None:
         desired_outcome = {
             "id": "arch",
             "name": "Arch Linux",
@@ -1100,7 +1104,7 @@ class TestOverall(DistroTestCase):
         # considered a valid distro release file:
         self._test_non_existing_release_file()
 
-    def test_centos5_release(self):
+    def test_centos5_release(self) -> None:
         desired_outcome = {
             "id": "centos",
             "name": "CentOS",
@@ -1122,7 +1126,7 @@ class TestOverall(DistroTestCase):
         }
         self._test_release_file_info("centos-release", desired_info)
 
-    def test_centos7_release(self):
+    def test_centos7_release(self) -> None:
         desired_outcome = {
             "id": "centos",
             "name": "CentOS Linux",
@@ -1144,7 +1148,7 @@ class TestOverall(DistroTestCase):
         }
         self._test_release_file_info("centos-release", desired_info)
 
-    def test_coreos_release(self):
+    def test_coreos_release(self) -> None:
         desired_outcome = {
             "id": "coreos",
             "name": "CoreOS",
@@ -1159,7 +1163,7 @@ class TestOverall(DistroTestCase):
         self._test_outcome(desired_outcome)
         self._test_non_existing_release_file()
 
-    def test_debian8_release(self):
+    def test_debian8_release(self) -> None:
         desired_outcome = {
             "id": "debian",
             "name": "Debian GNU/Linux",
@@ -1173,7 +1177,7 @@ class TestOverall(DistroTestCase):
         self._test_outcome(desired_outcome)
         self._test_non_existing_release_file()
 
-    def test_exherbo_release(self):
+    def test_exherbo_release(self) -> None:
         desired_outcome = {
             "id": "exherbo",
             "name": "Exherbo",
@@ -1181,7 +1185,7 @@ class TestOverall(DistroTestCase):
         }
         self._test_outcome(desired_outcome)
 
-    def test_fedora19_release(self):
+    def test_fedora19_release(self) -> None:
         desired_outcome = {
             "id": "fedora",
             "name": "Fedora",
@@ -1202,7 +1206,7 @@ class TestOverall(DistroTestCase):
         }
         self._test_release_file_info("fedora-release", desired_info)
 
-    def test_fedora23_release(self):
+    def test_fedora23_release(self) -> None:
         desired_outcome = {
             "id": "fedora",
             "name": "Fedora",
@@ -1223,7 +1227,7 @@ class TestOverall(DistroTestCase):
         }
         self._test_release_file_info("fedora-release", desired_info)
 
-    def test_fedora30_release(self):
+    def test_fedora30_release(self) -> None:
         desired_outcome = {
             "id": "fedora",
             "name": "Fedora",
@@ -1244,7 +1248,7 @@ class TestOverall(DistroTestCase):
         }
         self._test_release_file_info("fedora-release", desired_info)
 
-    def test_kvmibm1_release(self):
+    def test_kvmibm1_release(self) -> None:
         desired_outcome = {
             "id": "kvmibm",
             "name": "KVM for IBM z Systems",
@@ -1268,7 +1272,7 @@ class TestOverall(DistroTestCase):
         }
         self._test_release_file_info("base-release", desired_info)
 
-    def test_linuxmint17_release(self):
+    def test_linuxmint17_release(self) -> None:
         desired_outcome = {
             "id": "ubuntu",
             "name": "Ubuntu",
@@ -1284,7 +1288,7 @@ class TestOverall(DistroTestCase):
         self._test_outcome(desired_outcome)
         self._test_non_existing_release_file()
 
-    def test_mageia5_release(self):
+    def test_mageia5_release(self) -> None:
         desired_outcome = {
             "id": "mageia",
             "name": "Mageia",
@@ -1307,7 +1311,7 @@ class TestOverall(DistroTestCase):
         }
         self._test_release_file_info("mageia-release", desired_info)
 
-    def test_manjaro1512_release(self):
+    def test_manjaro1512_release(self) -> None:
         self._test_outcome(
             {
                 "id": "manjaro",
@@ -1326,7 +1330,7 @@ class TestOverall(DistroTestCase):
             "manjaro-release", {"id": "manjaro", "name": "Manjaro Linux"}
         )
 
-    def test_opensuse42_release(self):
+    def test_opensuse42_release(self) -> None:
         desired_outcome = {
             "id": "opensuse",
             "name": "openSUSE Leap",
@@ -1349,7 +1353,7 @@ class TestOverall(DistroTestCase):
         }
         self._test_release_file_info("SuSE-release", desired_info)
 
-    def test_oracle7_release(self):
+    def test_oracle7_release(self) -> None:
         desired_outcome = {
             "id": "oracle",
             "name": "Oracle Linux Server",
@@ -1370,7 +1374,7 @@ class TestOverall(DistroTestCase):
         distro_info = self._test_release_file_info("oracle-release", desired_info)
         assert "codename" not in distro_info
 
-    def test_raspbian7_release(self):
+    def test_raspbian7_release(self) -> None:
         desired_outcome = {
             "id": "raspbian",
             "name": "Raspbian GNU/Linux",
@@ -1385,7 +1389,7 @@ class TestOverall(DistroTestCase):
         self._test_outcome(desired_outcome)
         self._test_non_existing_release_file()
 
-    def test_raspbian8_release(self):
+    def test_raspbian8_release(self) -> None:
         desired_outcome = {
             "id": "raspbian",
             "name": "Raspbian GNU/Linux",
@@ -1400,7 +1404,7 @@ class TestOverall(DistroTestCase):
         self._test_outcome(desired_outcome)
         self._test_non_existing_release_file()
 
-    def test_rhel5_release(self):
+    def test_rhel5_release(self) -> None:
         desired_outcome = {
             "id": "rhel",
             "name": "Red Hat Enterprise Linux Server",
@@ -1422,7 +1426,7 @@ class TestOverall(DistroTestCase):
         }
         self._test_release_file_info("redhat-release", desired_info)
 
-    def test_rhel6_release(self):
+    def test_rhel6_release(self) -> None:
         desired_outcome = {
             "id": "rhel",
             "name": "Red Hat Enterprise Linux Server",
@@ -1444,7 +1448,7 @@ class TestOverall(DistroTestCase):
         }
         self._test_release_file_info("redhat-release", desired_info)
 
-    def test_rhel7_release(self):
+    def test_rhel7_release(self) -> None:
         desired_outcome = {
             "id": "rhel",
             "name": "Red Hat Enterprise Linux Server",
@@ -1467,7 +1471,7 @@ class TestOverall(DistroTestCase):
         }
         self._test_release_file_info("redhat-release", desired_info)
 
-    def test_slackware14_release(self):
+    def test_slackware14_release(self) -> None:
         desired_outcome = {
             "id": "slackware",
             "name": "Slackware",
@@ -1484,7 +1488,7 @@ class TestOverall(DistroTestCase):
         distro_info = self._test_release_file_info("slackware-version", desired_info)
         assert "codename" not in distro_info
 
-    def test_sles12_release(self):
+    def test_sles12_release(self) -> None:
         desired_outcome = {
             "id": "sles",
             "name": "SLES",
@@ -1506,7 +1510,7 @@ class TestOverall(DistroTestCase):
         }
         self._test_release_file_info("SuSE-release", desired_info)
 
-    def test_ubuntu14_release(self):
+    def test_ubuntu14_release(self) -> None:
         desired_outcome = {
             "id": "ubuntu",
             "name": "Ubuntu",
@@ -1526,7 +1530,7 @@ class TestOverall(DistroTestCase):
         # release file:
         self._test_non_existing_release_file()
 
-    def test_ubuntu16_release(self):
+    def test_ubuntu16_release(self) -> None:
         desired_outcome = {
             "id": "ubuntu",
             "name": "Ubuntu",
@@ -1546,7 +1550,7 @@ class TestOverall(DistroTestCase):
         # release file:
         self._test_non_existing_release_file()
 
-    def test_amazon2016_release(self):
+    def test_amazon2016_release(self) -> None:
         desired_outcome = {
             "id": "amzn",
             "name": "Amazon Linux AMI",
@@ -1560,13 +1564,12 @@ class TestOverall(DistroTestCase):
         }
         self._test_outcome(desired_outcome)
 
-    def test_amazon2014_release(self):
+    def test_amazon2014_release(self) -> None:
         # Amazon Linux 2014 only contains a system-release file.
         # distro doesn't currently handle it.
-        desired_outcome = {}
-        self._test_outcome(desired_outcome)
+        self._test_outcome({})
 
-    def test_scientific6_release(self):
+    def test_scientific6_release(self) -> None:
         desired_outcome = {
             "id": "rhel",
             "name": "Scientific Linux",
@@ -1588,7 +1591,7 @@ class TestOverall(DistroTestCase):
         }
         self._test_release_file_info("redhat-release", desired_info)
 
-    def test_scientific7_release(self):
+    def test_scientific7_release(self) -> None:
         desired_outcome = {
             "id": "rhel",
             "name": "Scientific Linux",
@@ -1611,7 +1614,7 @@ class TestOverall(DistroTestCase):
         }
         self._test_release_file_info("redhat-release", desired_info)
 
-    def test_gentoo_release(self):
+    def test_gentoo_release(self) -> None:
         desired_outcome = {
             "id": "gentoo",
             "name": "Gentoo",
@@ -1631,7 +1634,7 @@ class TestOverall(DistroTestCase):
         }
         self._test_release_file_info("gentoo-release", desired_info)
 
-    def test_openelec6_release(self):
+    def test_openelec6_release(self) -> None:
         desired_outcome = {
             "id": "openelec",
             "name": "OpenELEC",
@@ -1644,7 +1647,7 @@ class TestOverall(DistroTestCase):
         }
         self._test_outcome(desired_outcome)
 
-    def test_mandriva2011_release(self):
+    def test_mandriva2011_release(self) -> None:
         desired_outcome = {
             "id": "mandrivalinux",
             "name": "MandrivaLinux",
@@ -1665,7 +1668,7 @@ class TestOverall(DistroTestCase):
         }
         self._test_release_file_info("mandrake-release", desired_info)
 
-    def test_cloudlinux5_release(self):
+    def test_cloudlinux5_release(self) -> None:
         # Uses redhat-release only to get information.
         # The id of 'rhel' can only be fixed with issue #109.
         desired_outcome = {
@@ -1681,7 +1684,7 @@ class TestOverall(DistroTestCase):
         }
         self._test_outcome(desired_outcome)
 
-    def test_cloudlinux6_release(self):
+    def test_cloudlinux6_release(self) -> None:
         # Same as above, only has redhat-release.
         desired_outcome = {
             "id": "cloudlinux",
@@ -1696,7 +1699,7 @@ class TestOverall(DistroTestCase):
         }
         self._test_outcome(desired_outcome)
 
-    def test_cloudlinux7_release(self):
+    def test_cloudlinux7_release(self) -> None:
         desired_outcome = {
             "id": "cloudlinux",
             "codename": "Yury Malyshev",
@@ -1712,7 +1715,7 @@ class TestOverall(DistroTestCase):
         self._test_outcome(desired_outcome)
 
 
-def _bad_os_listdir(path="."):
+def _bad_os_listdir(path: str = ".") -> NoReturn:
     """This function is used by TestOverallWithEtcNotReadable to simulate
     a folder that cannot be called with os.listdir() but files are still
     readable. Forces distro to guess which *-release files are available."""
@@ -1721,12 +1724,14 @@ def _bad_os_listdir(path="."):
 
 @pytest.mark.skipif(not IS_LINUX, reason="Irrelevant on non-linux")
 class TestOverallWithEtcNotReadable(TestOverall):
-    def setup_method(self, test_method):
+    def setup_method(self, test_method: FunctionType) -> None:
         self._old_listdir = os.listdir
-        os.listdir = _bad_os_listdir
+        # Incompatible types in assignment (expression has type
+        # "Callable[[str], NoReturn]", variable has type overloaded function)
+        os.listdir = _bad_os_listdir  # type: ignore[assignment]
         super().setup_method(test_method)
 
-    def teardown_method(self, test_method):
+    def teardown_method(self, test_method: FunctionType) -> None:
         super().teardown_method(test_method)
         if os.listdir is _bad_os_listdir:
             os.listdir = self._old_listdir
@@ -1739,7 +1744,7 @@ class TestGetAttr(DistroTestCase):
     distros in `DISTROS`.
     """
 
-    def _test_attr(self, info_method, attr_method):
+    def _test_attr(self, info_method: str, attr_method: str) -> None:
         for dist in DISTROS:
             self._setup_for_distro(os.path.join(DISTROS_DIR, dist))
             _distro = distro.LinuxDistribution()
@@ -1750,25 +1755,25 @@ class TestGetAttr(DistroTestCase):
                 except AssertionError:
                     print(f"distro: {dist}, key: {key}")
 
-    def test_os_release_attr(self):
+    def test_os_release_attr(self) -> None:
         self._test_attr("os_release_info", "os_release_attr")
 
-    def test_lsb_release_attr(self):
+    def test_lsb_release_attr(self) -> None:
         self._test_attr("lsb_release_info", "lsb_release_attr")
 
-    def test_distro_release_attr(self):
+    def test_distro_release_attr(self) -> None:
         self._test_attr("distro_release_info", "distro_release_attr")
 
 
 @pytest.mark.skipif(not IS_LINUX, reason="Irrelevant on non-linux")
 class TestInfo(DistroTestCase):
-    def setup_method(self, test_method):
+    def setup_method(self, test_method: FunctionType) -> None:
         super().setup_method(test_method)
         self.ubuntu14_os_release = os.path.join(
             DISTROS_DIR, "ubuntu14", "etc", "os-release"
         )
 
-    def test_info(self):
+    def test_info(self) -> None:
         _distro = distro.LinuxDistribution(
             include_lsb=False,
             os_release_file=self.ubuntu14_os_release,
@@ -1786,7 +1791,7 @@ class TestInfo(DistroTestCase):
         info = _distro.info()
         assert info == desired_info
 
-        desired_info_diff = {"version": "14.04 (Trusty Tahr)"}
+        desired_info_diff: Dict[str, Any] = {"version": "14.04 (Trusty Tahr)"}
         desired_info.update(desired_info_diff)
         info = _distro.info(pretty=True)
         assert info == desired_info
@@ -1804,8 +1809,8 @@ class TestInfo(DistroTestCase):
         info = _distro.info(pretty=True, best=True)
         assert info == desired_info
 
-    def test_none(self):
-        def _test_none(info):
+    def test_none(self) -> None:
+        def _test_none(info: distro.InfoDict) -> None:
             assert info["id"] == ""
             assert info["version"] == ""
             assert info["like"] == ""
@@ -1832,26 +1837,28 @@ class TestInfo(DistroTestCase):
         info = _distro.info(pretty=True, best=True)
         _test_none(info)
 
-    def test_linux_distribution(self):
+    def test_linux_distribution(self) -> None:
         _distro = distro.LinuxDistribution(
             include_lsb=False, os_release_file=self.ubuntu14_os_release
         )
         i = _distro.linux_distribution()
         assert i == ("Ubuntu", "14.04", "Trusty Tahr")
 
-    def test_linux_distribution_full_false(self):
+    def test_linux_distribution_full_false(self) -> None:
         _distro = distro.LinuxDistribution(
             include_lsb=False, os_release_file=self.ubuntu14_os_release
         )
         i = _distro.linux_distribution(full_distribution_name=False)
         assert i == ("ubuntu", "14.04", "Trusty Tahr")
 
-    def test_all(self):
+    def test_all(self) -> None:
         """Test info() by comparing its results with the results of specific
         consolidated accessor functions.
         """
 
-        def _test_all(info, best=False, pretty=False):
+        def _test_all(
+            info: distro.InfoDict, best: bool = False, pretty: bool = False
+        ) -> None:
             assert info["id"] == _distro.id()
             assert info["version"] == _distro.version(pretty=pretty, best=best)
             assert info["version_parts"]["major"] == _distro.major_version(best=best)
@@ -1886,107 +1893,103 @@ class TestInfo(DistroTestCase):
 class TestOSReleaseParsing:
     """Test the parsing of os-release files."""
 
-    def setup_method(self, test_method):
-        self.distro = distro.LinuxDistribution(
-            include_lsb=False, os_release_file=None, distro_release_file=None
-        )
+    def setup_method(self, test_method: FunctionType) -> None:
+        self.distro = distro.LinuxDistribution(include_lsb=False)
 
-        self.distro.debug = True
-
-    def _get_props(self, input):
+    def _get_props(self, input: str) -> Dict[str, str]:
         return self.distro._parse_os_release_content(io.StringIO(input))
 
-    def _test_zero_length_props(self, input):
+    def _test_zero_length_props(self, input: str) -> None:
         props = self._get_props(input)
         assert len(props) == 0
 
-    def _test_empty_value(self, input):
+    def _test_empty_value(self, input: str) -> None:
         props = self._get_props(input)
         assert props.get("key", None) == ""
 
-    def _test_parsed_value(self, input):
+    def _test_parsed_value(self, input: str) -> None:
         props = self._get_props(input)
         assert props.get("key", None) == "value"
 
-    def test_kv_01_empty_file(self):
+    def test_kv_01_empty_file(self) -> None:
         self._test_zero_length_props("")
 
-    def test_kv_02_empty_line(self):
+    def test_kv_02_empty_line(self) -> None:
         self._test_zero_length_props("\n")
 
-    def test_kv_03_empty_line_with_crlf(self):
+    def test_kv_03_empty_line_with_crlf(self) -> None:
         self._test_zero_length_props("\r\n")
 
-    def test_kv_04_empty_line_with_just_cr(self):
+    def test_kv_04_empty_line_with_just_cr(self) -> None:
         self._test_zero_length_props("\r")
 
-    def test_kv_05_comment(self):
+    def test_kv_05_comment(self) -> None:
         self._test_zero_length_props("# KEY=value\n")
 
-    def test_kv_06_empty_value(self):
+    def test_kv_06_empty_value(self) -> None:
         self._test_empty_value("KEY=\n")
 
-    def test_kv_07_empty_value_single_quoted(self):
+    def test_kv_07_empty_value_single_quoted(self) -> None:
         self._test_empty_value("KEY=''\n")
 
-    def test_kv_08_empty_value_double_quoted(self):
+    def test_kv_08_empty_value_double_quoted(self) -> None:
         self._test_empty_value('KEY=""\n')
 
-    def test_kv_09_word(self):
+    def test_kv_09_word(self) -> None:
         self._test_parsed_value("KEY=value\n")
 
-    def test_kv_10_word_no_newline(self):
+    def test_kv_10_word_no_newline(self) -> None:
         self._test_parsed_value("KEY=value")
 
-    def test_kv_11_word_with_crlf(self):
+    def test_kv_11_word_with_crlf(self) -> None:
         self._test_parsed_value("KEY=value\r\n")
 
-    def test_kv_12_word_with_just_cr(self):
+    def test_kv_12_word_with_just_cr(self) -> None:
         self._test_parsed_value("KEY=value\r")
 
-    def test_kv_13_word_with_multi_blanks(self):
+    def test_kv_13_word_with_multi_blanks(self) -> None:
         self._test_empty_value("KEY=  cmd   \n")
         # Note: Without quotes, this assigns the empty string, and 'cmd' is
         # a separate token that is being ignored (it would be a command
         # in the shell).
 
-    def test_kv_14_unquoted_words(self):
+    def test_kv_14_unquoted_words(self) -> None:
         self._test_parsed_value("KEY=value cmd\n")
 
-    def test_kv_15_double_quoted_words(self):
+    def test_kv_15_double_quoted_words(self) -> None:
         props = self._get_props('KEY="a simple value" cmd\n')
         assert props.get("key", None) == "a simple value"
 
-    def test_kv_16_double_quoted_words_with_multi_blanks(self):
+    def test_kv_16_double_quoted_words_with_multi_blanks(self) -> None:
         props = self._get_props('KEY=" a  simple   value "\n')
         assert props.get("key", None) == " a  simple   value "
 
-    def test_kv_17_double_quoted_word_with_single_quote(self):
+    def test_kv_17_double_quoted_word_with_single_quote(self) -> None:
         props = self._get_props('KEY="it\'s value"\n')
         assert props.get("key", None) == "it's value"
 
-    def test_kv_18_double_quoted_word_with_double_quote(self):
+    def test_kv_18_double_quoted_word_with_double_quote(self) -> None:
         props = self._get_props('KEY="a \\"bold\\" move"\n')
         assert props.get("key", None) == 'a "bold" move'
 
-    def test_kv_19_single_quoted_words(self):
+    def test_kv_19_single_quoted_words(self) -> None:
         props = self._get_props("KEY='a simple value'\n")
         assert props.get("key", None) == "a simple value"
 
-    def test_kv_20_single_quoted_words_with_multi_blanks(self):
+    def test_kv_20_single_quoted_words_with_multi_blanks(self) -> None:
         props = self._get_props("KEY=' a  simple   value '\n")
         assert props.get("key", None) == " a  simple   value "
 
-    def test_kv_21_single_quoted_word_with_double_quote(self):
+    def test_kv_21_single_quoted_word_with_double_quote(self) -> None:
         props = self._get_props("KEY='a \"bold\" move'\n")
         assert props.get("key", None) == 'a "bold" move'
 
-    def test_kv_22_quoted_unicode_wordchar(self):
+    def test_kv_22_quoted_unicode_wordchar(self) -> None:
         # "wordchar" means it is in the shlex.wordchars variable.
         props = self._get_props('KEY="wordchar: \u00CA (E accent grave)"\n')
         assert props.get("key", None) == "wordchar: \u00CA (E accent grave)"
 
-    def test_kv_23_quoted_unicode_non_wordchar(self):
+    def test_kv_23_quoted_unicode_non_wordchar(self) -> None:
         # "non-wordchar" means it is not in the shlex.wordchars variable.
         props = self._get_props(
             'KEY="non-wordchar: \u00A1 (inverted exclamation mark)"\n'
@@ -1995,22 +1998,22 @@ class TestOSReleaseParsing:
             props.get("key", None) == "non-wordchar: \u00A1 (inverted exclamation mark)"
         )
 
-    def test_kv_24_double_quoted_entire_single_quoted_word(self):
+    def test_kv_24_double_quoted_entire_single_quoted_word(self) -> None:
         props = self._get_props("KEY=\"'value'\"\n")
         assert props.get("key", None) == "'value'"
 
-    def test_kv_25_single_quoted_entire_double_quoted_word(self):
+    def test_kv_25_single_quoted_entire_double_quoted_word(self) -> None:
         props = self._get_props("KEY='\"value\"'\n")
         assert props.get("key", None) == '"value"'
 
-    def test_kv_26_double_quoted_multiline(self):
+    def test_kv_26_double_quoted_multiline(self) -> None:
         props = self.distro._parse_os_release_content(
             io.StringIO('KEY="a multi\n' 'line value"\n')
         )
         assert props.get("key", None) == "a multi\nline value"
         # TODO: Find out why the result is not 'a multi line value'
 
-    def test_kv_27_double_quoted_multiline_2(self):
+    def test_kv_27_double_quoted_multiline_2(self) -> None:
         props = self._get_props("KEY=' a  simple   value '\n")
         props = self.distro._parse_os_release_content(
             io.StringIO('KEY="a multi\n' 'line=value"\n')
@@ -2018,22 +2021,22 @@ class TestOSReleaseParsing:
         assert props.get("key", None) == "a multi\nline=value"
         # TODO: Find out why the result is not 'a multi line=value'
 
-    def test_kv_28_double_quoted_word_with_equal(self):
+    def test_kv_28_double_quoted_word_with_equal(self) -> None:
         props = self._get_props('KEY="var=value"\n')
         assert props.get("key", None) == "var=value"
 
-    def test_kv_29_single_quoted_word_with_equal(self):
+    def test_kv_29_single_quoted_word_with_equal(self) -> None:
         props = self._get_props("KEY='var=value'\n")
         assert props.get("key", None) == "var=value"
 
-    def test_kx_01(self):
+    def test_kx_01(self) -> None:
         props = self.distro._parse_os_release_content(
             io.StringIO("KEY1=value1\n" 'KEY2="value  2"\n')
         )
         assert props.get("key1", None) == "value1"
         assert props.get("key2", None) == "value  2"
 
-    def test_kx_02(self):
+    def test_kx_02(self) -> None:
         props = self.distro._parse_os_release_content(
             io.StringIO("# KEY1=value1\n" 'KEY2="value  2"\n')
         )
@@ -2047,10 +2050,10 @@ class TestGlobal:
     arguments.
     """
 
-    def setup_method(self, test_method):
+    def setup_method(self, test_method: FunctionType) -> None:
         pass
 
-    def test_global(self):
+    def test_global(self) -> None:
         # Because the module-level functions use the module-global
         # LinuxDistribution instance, it would influence the tested
         # code too much if we mocked that in order to use the distro
@@ -2059,7 +2062,9 @@ class TestGlobal:
         # compare the result of the global functions with the result
         # of the methods on the global LinuxDistribution object.
 
-        def _test_consistency(function, kwargs=None):
+        def _test_consistency(
+            function: str, kwargs: Optional[Dict[str, Any]] = None
+        ) -> None:
             kwargs = kwargs or {}
             method_result = getattr(MODULE_DISTRO, function)(**kwargs)
             function_result = getattr(distro, function)(**kwargs)
@@ -2137,7 +2142,7 @@ class TestGlobal:
 class TestRepr:
     """Test the __repr__() method."""
 
-    def test_repr(self):
+    def test_repr(self) -> None:
         # We test that the class name and the names of all instance attributes
         # show up in the repr() string.
         repr_str = repr(distro._distro)


### PR DESCRIPTION
The tests are a big consumer of the distro API. By running mypy on
tests, we:

- Help verify the tests are using the distro API as designed.

- Help verify the API types are internally consistent when used in test
  scenario which should represent real life scenarios.

- Help catch non-representative tests that use the API in non-realstic
  ways.

- Help verify pytest is used as designed.