### PR TITLE
Fix Amazon Linux identifier in `id()` documentation

### DIFF
--- a/distro.py
+++ b/distro.py
@@ -195,7 +195,7 @@ def id() -> str:
     "fedora"        Fedora
     "sles"          SUSE Linux Enterprise Server
     "opensuse"      openSUSE
-    "amazon"        Amazon Linux
+    "amzn"          Amazon Linux
     "arch"          Arch Linux
     "cloudlinux"    CloudLinux OS
     "exherbo"       Exherbo Linux

--- a/tests/test_distro.py
+++ b/tests/test_distro.py
@@ -1046,7 +1046,6 @@ class TestOverall(DistroTestCase):
     TODO: This class should have testcases for all distros that are claimed
     to be reliably maintained w.r.t. to their ID (see `id()`). Testcases for
     the following distros are still missing:
-      * `amazon` - Amazon Linux
       * `gentoo` - GenToo Linux
       * `ibm_powerkvm` - IBM PowerKVM
       * `parallels` - Parallels


### PR DESCRIPTION
... and removes `amazon` from missing distros test cases

> closes #252 

---

Thanks 🙇
