### PR TITLE
perf: Query distro.version sources lazily

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+ENHANCEMENTS:
+* Optimize distro.version() method by querying version sources lazily [[#379](https://github.com/python-distro/distro/pull/379)]
+
 ## 1.9.0 (2023.12.19)
 
 ENHANCEMENTS:

--- a/src/distro/distro.py
+++ b/src/distro/distro.py
@@ -42,6 +42,7 @@ from typing import (
     Callable,
     Dict,
     Iterable,
+    List,
     Optional,
     Sequence,
     TextIO,
@@ -912,38 +913,42 @@ class LinuxDistribution:
 
         For details, see :func:`distro.version`.
         """
-        versions = [
-            self.os_release_attr("version_id"),
-            self.lsb_release_attr("release"),
-            self.distro_release_attr("version_id"),
-            self._parse_distro_release_content(self.os_release_attr("pretty_name")).get(
-                "version_id", ""
-            ),
-            self._parse_distro_release_content(
+        # Optimization: query the version from subsequent sources lazily to avoid
+        # as many expensive subprocess calls as possible (notably via lsb_release).
+        version_sources: List[Callable[[], str]] = [
+            lambda: self.os_release_attr("version_id"),
+            lambda: self.lsb_release_attr("release"),
+            lambda: self.distro_release_attr("version_id"),
+            lambda: self._parse_distro_release_content(
+                self.os_release_attr("pretty_name")
+            ).get("version_id", ""),
+            lambda: self._parse_distro_release_content(
                 self.lsb_release_attr("description")
             ).get("version_id", ""),
-            self._uname_attr("release"),
+            lambda: self._uname_attr("release"),
         ]
         if self._uname_attr("id").startswith("aix"):
             # On AIX platforms, prefer oslevel command output.
-            versions.insert(0, self.oslevel_info())
+            version_sources.insert(0, lambda: self.oslevel_info())
         elif self.id() == "debian" or "debian" in self.like().split():
             # On Debian-like, add debian_version file content to candidates list.
-            versions.append(self._debian_version)
+            version_sources.append(lambda: self._debian_version)
             if self._distro_release_info.get("id") == "armbian":
                 # On Armbian, add version from armbian-release file to candidates list.
-                versions.append(self._armbian_version)
+                version_sources.append(lambda: self._armbian_version)
         version = ""
         if best:
             # This algorithm uses the last version in priority order that has
             # the best precision. If the versions are not in conflict, that
             # does not matter; otherwise, using the last one instead of the
             # first one might be considered a surprise.
-            for v in versions:
+            for src in version_sources:
+                v = src()
                 if v.count(".") > version.count(".") or version == "":
                     version = v
         else:
-            for v in versions:
+            for src in version_sources:
+                v = src()
                 if v != "":
                     version = v
                     break


### PR DESCRIPTION
Hey, I first wanted to say thanks for maintaining distro. From the pip team, we appreciate it! 

---

When `/etc/os-release` provides sufficiently high-quality version information directly, there is no need to call `lsb_release` in a subprocess or query any other version.

This speeds up distro.version() massively when `lsb_release` is slow to execute, like on Ubuntu 26.04 LTS where it can easily take north of 15ms.

For context, pip uses distro.version() to populate its user-agent header so we'd like this function to be as fast as reasonably possible.

For benchmarking, you can use this which is equivalent to what pip does:

```python
import distro
import time

def run():
    t0 = time.perf_counter()
    linux_distribution = distro.name(), distro.version(), distro.codename()
    t1 = time.perf_counter()

    print(f"elapsed: {(t1 - t0)*1000:.2f}ms")

run()
```

Under CPython 3.15's new sampling profiler on Ubuntu 26.04 LTS:

```
~/dev/oss/distro ❯ python -m profiling.sampling run -r 30khz test.py
elapsed: 16.21ms
Captured 1,028 samples in 0.03 seconds
Sample rate: 30,302.98 samples/sec
Error rate: 24.61
Profile Stats:
       nsamples   sample%  tottime (ms)    cumul%  cumtime (ms)  filename:lineno(function)
        429/429      55.5        14.157      55.5        14.157  subprocess.py:1376(Popen.communicate)
        157/291      20.3         5.181      37.6         9.603  <frozen importlib._bootstrap>:549(_call_with_frames_removed)
          45/45       5.8         1.485       5.8         1.485  <frozen importlib._bootstrap_external>:500(_compile_bytecode)
          24/24       3.1         0.792       3.1         0.792  subprocess.py:2080(Popen._execute_child)
            8/8       1.0         0.264       1.0         0.264  <frozen genericpath>:40(isfile)
            5/5       0.6         0.165       0.6         0.165  <frozen importlib._bootstrap_external>:213(_write_atomic)
            5/5       0.6         0.165       0.6         0.165  _parser.py:450(_uniq)
            4/4       0.5         0.132       0.5         0.132  <frozen importlib._bootstrap_external>:923(FileLoader.get_data)
            3/3       0.4         0.099       0.4         0.099  <frozen importlib._bootstrap_external>:517(_code_to_timestamp_pyc)
            3/3       0.4         0.099       0.4         0.099  <frozen importlib._bootstrap_external>:152(_path_stat)
            3/3       0.4         0.099       0.4         0.099  __init__.py:447(namedtuple)
            3/3       0.4         0.099       0.4         0.099  distro.py:1351(LinuxDistribution._distro_release_info)
            2/2       0.3         0.066       0.3         0.066  <frozen importlib._bootstrap_external>:211(_write_atomic)
            2/2       0.3         0.066       0.3         0.066  argparse.py:1020(<module>)
            2/2       0.3         0.066       0.3         0.066  __init__.py:515(namedtuple)

Legend:
  nsamples: Direct/Cumulative samples (direct executing / on call stack)
  sample%: Percentage of total samples this function was directly executing
  tottime: Estimated total time spent directly in this function
  cumul%: Percentage of total samples when this function was on the call stack
  cumtime: Estimated cumulative time (including time in called functions)
  filename:lineno(function): Function location and name
```