### PR TITLE
Remove Codecov integration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,19 +61,12 @@ jobs:
       - name: Run tox
         run: tox -e py
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          files: .coverage
-
   windows:
     name: Windows
     runs-on: windows-latest
 
     steps:
       - uses: actions/checkout@v5
-
-      - uses: codecov/codecov-action@v3
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,0 +1,43 @@
+name: Coverage
+
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: write
+
+jobs:
+  coverage:
+    name: Generate coverage badge
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install tox and genbadge
+        run: python -m pip install tox "genbadge[coverage]"
+
+      - name: Run tests with coverage
+        run: tox -e py -- --cov-report xml
+
+      - name: Generate coverage badge
+        run: genbadge coverage -i coverage.xml -o coverage.svg
+
+      - name: Publish badge to coverage-badge branch
+        run: |
+          cp coverage.svg "${RUNNER_TEMP}/coverage.svg"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout --orphan coverage-badge
+          git rm -rf . > /dev/null 2>&1 || true
+          cp "${RUNNER_TEMP}/coverage.svg" coverage.svg
+          git add coverage.svg
+          git commit -m "Update coverage badge"
+          git push --force origin coverage-badge

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ Distro - an OS platform information API
 [![CI Status](https://github.com/python-distro/distro/workflows/CI/badge.svg)](https://github.com/python-distro/distro/actions/workflows/ci.yaml)
 [![PyPI version](http://img.shields.io/pypi/v/distro.svg)](https://pypi.python.org/pypi/distro)
 [![Supported Python Versions](https://img.shields.io/pypi/pyversions/distro.svg)](https://img.shields.io/pypi/pyversions/distro.svg)
-[![Code Coverage](https://codecov.io/github/python-distro/distro/coverage.svg?branch=master)](https://codecov.io/github/python-distro/distro?branch=master)
 [![Is Wheel](https://img.shields.io/pypi/wheel/distro.svg?style=flat)](https://pypi.python.org/pypi/distro)
 [![Latest Github Release](https://readthedocs.org/projects/distro/badge/?version=stable)](http://distro.readthedocs.io/en/latest/)
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Distro - an OS platform information API
 [![CI Status](https://github.com/python-distro/distro/workflows/CI/badge.svg)](https://github.com/python-distro/distro/actions/workflows/ci.yaml)
 [![PyPI version](http://img.shields.io/pypi/v/distro.svg)](https://pypi.python.org/pypi/distro)
 [![Supported Python Versions](https://img.shields.io/pypi/pyversions/distro.svg)](https://img.shields.io/pypi/pyversions/distro.svg)
+[![Code Coverage](https://raw.githubusercontent.com/python-distro/distro/coverage-badge/coverage.svg)](https://github.com/python-distro/distro/actions/workflows/coverage.yaml)
 [![Is Wheel](https://img.shields.io/pypi/wheel/distro.svg?style=flat)](https://pypi.python.org/pypi/distro)
 [![Latest Github Release](https://readthedocs.org/projects/distro/badge/?version=stable)](http://distro.readthedocs.io/en/latest/)
 


### PR DESCRIPTION
## Summary
- Remove the Codecov coverage upload steps from the CI workflow (`.github/workflows/ci.yaml`)
- Create a workflow that updates a branch that contains the upated coverage report.

## Why
It works, and it's self-contained.